### PR TITLE
Updated stripFilter to strip html tags completely and added more tests (fixes #485)

### DIFF
--- a/__tests__/utils/FilterHelpers.spec.ts
+++ b/__tests__/utils/FilterHelpers.spec.ts
@@ -18,9 +18,17 @@ import { FilterHelpers } from '@/core/utils/FilterHelpers'
 describe('stripFilter', () => {
   // should return a string without tags
   test.each([
-    ['unless tags', 'unless tags'],
-    ['<script>/>good', 'script/good'],
-    ['<>>', ''],
+    ['no tags', 'no tags'],
+    ['no tags;\'"#!?%&/8{}', 'no tags;\'"#!?%&/8{}'],
+    ['<script>/>good', '/>good'],
+    ['<>>', '<>>'],
+    ['<a>>', '>'],
+    ['test <img src="" /> another', 'test  another'],
+    ['<img src="" />', ''],
+    ['<parent <child <sub />></child>></parent>', '>>'],
+    ['<script>alert("abc");</script>', 'alert("abc");'],
+    ['/><script>alert("abc");</script>', '/>alert("abc");'],
+    ['This is a normal text <img src="nothing" onerror="alert("abc");" />', 'This is a normal text '],
   ])('FilterHelpers.stripFilter(%s)', (a, expected) => {
     expect(FilterHelpers.stripFilter(a)).toBe(expected)
   })

--- a/src/core/utils/FilterHelpers.ts
+++ b/src/core/utils/FilterHelpers.ts
@@ -19,11 +19,30 @@ export class FilterHelpers {
    * replace all tags
    * @param inputStr
    */
-  public static stripFilter(inputStr: string) {
-    const isHtmlTag = new RegExp(/<[^>]*>/).test(inputStr)
-    if (isHtmlTag) {
-      inputStr = inputStr.replace(/[<>]/g, '')
-    }
-    return inputStr
+  public static stripFilter(inputStr: string, allowed: string = '') {
+    // making sure the allowed arg is a string containing only tags in lowercase (<a><b><c>)
+    allowed = (((allowed || '') + '').toLowerCase().match(/<[a-z][a-z0-9]*>/g) || []).join('')
+
+    const tags = /<\/?([a-z0-9]*)\b[^>]*>?/gi
+    const commentsAndPhpTags = /<!--[\s\S]*?-->|<\?(?:php)?[\s\S]*?\?>/gi
+
+    // removes tha '<' char at the end of the string to replicate PHP's behaviour
+    let after = inputStr
+    after = after.substring(after.length - 1) === '<' ? after.substring(0, after.length - 1) : after
+
+    // recursively remove tags to ensure that the returned string doesn't contain
+    // forbidden tags after previous passes (e.g. '<<bait/>switch/>')
+    let before
+    do {
+      before = after
+      after = before.replace(commentsAndPhpTags, '').replace(tags, function ($0, $1) {
+        return allowed.indexOf('<' + $1.toLowerCase() + '>') > -1 ? $0 : ''
+      })
+
+      // return once no more tags are removed
+      if (before === after) {
+        return after
+      }
+    } while (before !== after)
   }
 }

--- a/src/store/Notification.ts
+++ b/src/store/Notification.ts
@@ -17,6 +17,7 @@ import Vue from 'vue'
 // internal dependencies
 import app from '@/main'
 import { AwaitLock } from './AwaitLock'
+import { FilterHelpers } from '../core/utils/FilterHelpers'
 
 const Lock = AwaitLock.create()
 
@@ -45,16 +46,18 @@ export default {
       state.initialized = initialized
     },
     add: (state, payload) => {
+      // strip tags to remove XSS vulnerability
+      const message = FilterHelpers.stripFilter(payload.message)
       const history = state.history
       history.push({
         level: payload.level || 'warning',
-        message: payload.message,
+        message: message,
       })
       Vue.set(state, 'history', history)
 
       /// region trigger notice UI
       app.$Notice.destroy()
-      app.$Notice[payload.level]({ title: app.$t(payload.message) })
+      app.$Notice[payload.level]({ title: app.$t(message) })
       /// end-region trigger notice UI
     },
   },


### PR DESCRIPTION
#### Added

- Added unit tests for stripFilter filter to remove HTML tags from strings 
- Added PHP `strip_tags` alike implementation for stripFilter (recursive compatibility)

#### Fixed

- Updated stripFilter to strip html tags completely (fixes #485)