### PR TITLE
gh#480 SignerSelector is added to the ns create alias form and SignerFilter is added to namespaces list

### DIFF
--- a/src/components/SignerFilter/SignerFilter.vue
+++ b/src/components/SignerFilter/SignerFilter.vue
@@ -13,9 +13,6 @@
 </template>
 <script lang="ts">
 // @ts-ignore
-import { TransactionAddressFilterTs } from './TransactionAddressFilterTs'
-export default class TransactionAddressFilter extends TransactionAddressFilterTs {}
+import { SignerFilterTs } from './SignerFilterTs'
+export default class SignerFilter extends SignerFilterTs {}
 </script>
-<style lang="less" scoped>
-@import './TransactionAddressFilter.less';
-</style>

--- a/src/components/SignerFilter/SignerFilterTs.ts
+++ b/src/components/SignerFilter/SignerFilterTs.ts
@@ -9,7 +9,7 @@ import { mapGetters } from 'vuex'
     }),
   },
 })
-export class TransactionAddressFilterTs extends Vue {
+export class SignerFilterTs extends Vue {
   @Prop({ default: [] })
   public signers: Signer[]
 

--- a/src/components/TableDisplay/TableDisplay.less
+++ b/src/components/TableDisplay/TableDisplay.less
@@ -118,6 +118,8 @@
         color: @grayDark;
       }
       .user-operation {
+        display: flex;
+        justify-content: flex-end;
         position: absolute;
         right: 0.5rem;
         bottom: 0.2rem;
@@ -127,6 +129,53 @@
           font-weight: 600;
           &:hover {
             cursor: pointer;
+          }
+        }
+        .table-filter-item-container {
+          margin: 0.07rem 0.2rem 0 0;
+        }
+        /deep/.ivu-select {
+          .ivu-select-selection {
+            font-size: @normalFont;
+
+            &:hover {
+              color: @white;
+              background-color: @purpleDark;
+
+              .ivu-icon-ios-arrow-down::before {
+                color: @white !important;
+              }
+              .ivu-select-prefix {
+                color: @white;
+              }
+            }
+
+            .ivu-select-prefix {
+              color: @purpleDark;
+            }
+          }
+
+          .ivu-select-visible {
+            .ivu-select-selection {
+              color: @white !important;
+              background-color: @purpleDark;
+              border: 0.01rem solid @purpleDark;
+            }
+
+            .ivu-icon-ios-arrow-down::before {
+              color: @white !important;
+            }
+
+            .ivu-select-prefix {
+              color: @white;
+            }
+          }
+          .ivu-select-group-title {
+            font-size: @smallerFont !important;
+          }
+
+          .ivu-select-item {
+            font-size: @smallFont !important;
           }
         }
       }

--- a/src/components/TableDisplay/TableDisplay.vue
+++ b/src/components/TableDisplay/TableDisplay.vue
@@ -4,11 +4,16 @@
       <div class="table-title-container section-title">
         <slot name="table-title" />
         <div class="user-operation">
-          <Checkbox v-model="showExpired">
+          <Checkbox class="table-filter-item-container" v-model="showExpired">
             <span v-show="assetType === 'mosaic'">{{ $t('show_expired_mosaics') }}</span>
             <span v-show="assetType === 'namespace'">{{ $t('show_expired_namespaces') }}</span>
           </Checkbox>
-          <span @click="onRefresh"><Icon :class="{ 'animation-rotate': isRefreshing }" type="ios-sync" /></span>
+          <div v-if="signers.length > 1">
+            <SignerFilter :signers="signers" @signer-change="onSignerSelectorChange" />
+          </div>
+          <span class="table-filter-item-container" @click="onRefresh">
+            <Icon :class="{ 'animation-rotate': isRefreshing }" type="ios-sync" />
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/TableDisplay/TableDisplayTs.ts
+++ b/src/components/TableDisplay/TableDisplayTs.ts
@@ -43,6 +43,9 @@ import { NamespaceModel } from '@/core/database/entities/NamespaceModel'
 import { MosaicModel } from '@/core/database/entities/MosaicModel'
 import { NetworkConfigurationModel } from '@/core/database/entities/NetworkConfigurationModel'
 import { AccountModel } from '@/core/database/entities/AccountModel'
+import { Signer } from '@/store/Account'
+// @ts-ignore
+import SignerFilter from '@/components/SignerFilter/SignerFilter.vue'
 
 @Component({
   components: {
@@ -51,6 +54,7 @@ import { AccountModel } from '@/core/database/entities/AccountModel'
     FormAliasTransaction,
     FormExtendNamespaceDurationTransaction,
     FormMosaicSupplyChangeTransaction,
+    SignerFilter,
   },
   computed: {
     ...mapGetters({
@@ -59,6 +63,7 @@ import { AccountModel } from '@/core/database/entities/AccountModel'
       holdMosaics: 'mosaic/holdMosaics',
       ownedNamespaces: 'namespace/ownedNamespaces',
       networkConfiguration: 'network/networkConfiguration',
+      signers: 'account/signers',
     }),
   },
 })
@@ -97,6 +102,22 @@ export class TableDisplayTs extends Vue {
   private currentHeight: number
 
   private networkConfiguration: NetworkConfigurationModel
+
+  /**
+   * current signers
+   */
+  public signers: Signer[]
+
+  /**
+   * Hook called when the signer selector has changed
+   * @protected
+   */
+  protected onSignerSelectorChange(address: string): void {
+    // clear previous account transactions
+    if (address) {
+      this.$store.dispatch('account/SET_CURRENT_SIGNER', { address: Address.createFromRawAddress(address) })
+    }
+  }
 
   /**
    * Current table sorting state

--- a/src/components/TransactionList/TransactionListFilters/TransactionListFilters.vue
+++ b/src/components/TransactionList/TransactionListFilters/TransactionListFilters.vue
@@ -4,7 +4,7 @@
       <TransactionStatusFilter @status-change="onStatusSelectorChange" />
     </div>
     <div v-if="signers.length > 1" class="transaction-list-filter-container">
-      <TransactionAddressFilter :signers="signers" @signer-change="onSignerSelectorChange" />
+      <SignerFilter :signers="signers" @signer-change="onSignerSelectorChange" />
     </div>
     <div class="button-refresh-container">
       <ButtonRefresh @click="refresh" />

--- a/src/components/TransactionList/TransactionListFilters/TransactionListFiltersTs.ts
+++ b/src/components/TransactionList/TransactionListFilters/TransactionListFiltersTs.ts
@@ -18,7 +18,7 @@ import { mapGetters } from 'vuex'
 import { Component, Vue } from 'vue-property-decorator'
 // child components
 // @ts-ignore
-import TransactionAddressFilter from '@/components/TransactionList/TransactionListFilters/TransactionAddressFilter/TransactionAddressFilter.vue'
+import SignerFilter from '@/components/SignerFilter/SignerFilter.vue'
 // @ts-ignore
 import TransactionStatusFilter from '@/components/TransactionList/TransactionListFilters/TransactionStatusFilter/TransactionStatusFilter.vue'
 //@ts-ignore
@@ -29,7 +29,7 @@ import { TransactionGroupState } from '@/store/Transaction'
 import { Address } from 'symbol-sdk'
 
 @Component({
-  components: { TransactionAddressFilter, TransactionStatusFilter, ButtonRefresh },
+  components: { SignerFilter, TransactionStatusFilter, ButtonRefresh },
   computed: {
     ...mapGetters({
       currentAccount: 'account/currentAccount',

--- a/src/views/forms/FormAliasTransaction/FormAliasTransaction.vue
+++ b/src/views/forms/FormAliasTransaction/FormAliasTransaction.vue
@@ -2,6 +2,8 @@
   <FormWrapper>
     <ValidationObserver ref="observer" v-slot="{ handleSubmit }" slim>
       <form onsubmit="event.preventDefault()" class="form-container">
+        <SignerSelector v-model="formItems.signerAddress" :signers="signers" @input="onChangeSigner" />
+
         <!-- UNLINK alias action -->
         <FormRow v-if="aliasAction === AliasAction.Unlink">
           <template v-slot:inputs>

--- a/src/views/forms/FormAliasTransaction/FormAliasTransactionTs.ts
+++ b/src/views/forms/FormAliasTransaction/FormAliasTransactionTs.ts
@@ -52,6 +52,8 @@ import ModalTransactionConfirmation from '@/views/modals/ModalTransactionConfirm
 import MaxFeeAndSubmit from '@/components/MaxFeeAndSubmit/MaxFeeAndSubmit.vue'
 import { MosaicModel } from '@/core/database/entities/MosaicModel'
 import { NamespaceModel } from '@/core/database/entities/NamespaceModel'
+// @ts-ignore
+import SignerSelector from '@/components/SignerSelector/SignerSelector.vue'
 
 @Component({
   components: {
@@ -66,6 +68,7 @@ import { NamespaceModel } from '@/core/database/entities/NamespaceModel'
     MaxFeeSelector,
     ModalTransactionConfirmation,
     MaxFeeAndSubmit,
+    SignerSelector,
   },
   computed: {
     ...mapGetters({
@@ -104,6 +107,7 @@ export class FormAliasTransactionTs extends FormTransactionBase {
     aliasTarget: null,
     aliasAction: null,
     maxFee: 0,
+    signerAddress: '',
   }
 
   /**

--- a/src/views/forms/FormAliasTransaction/FormAliasTransactionTs.ts
+++ b/src/views/forms/FormAliasTransaction/FormAliasTransactionTs.ts
@@ -177,6 +177,10 @@ export class FormAliasTransactionTs extends FormTransactionBase {
     // TransactionType.ADDRESS_ALIAS, ) this.setTransactions([transaction as AliasTransaction])
     // this.isAwaitingSignature = true return }
 
+    this.formItems.signerAddress = this.selectedSigner
+      ? this.selectedSigner.address.plain()
+      : this.currentAccount.address
+
     /**
      * Helper function to get the alias target as a string
      * @param {(MosaicId | Address)} aliasTarget


### PR DESCRIPTION
In order to allow multi-sig account co-signers to list and manage namespace links, SignerSelector is added to ns->create an alias form and SignerFilter is added to namespace&mosaic list pages.

<img width="2000" alt="Screenshot 2020-08-17 at 12 31 35" src="https://user-images.githubusercontent.com/6256269/90391804-a616b680-e085-11ea-9a99-4b0c554f6aff.png">
<img width="1974" alt="Screenshot 2020-08-17 at 12 30 58" src="https://user-images.githubusercontent.com/6256269/90391819-ad3dc480-e085-11ea-86c0-103d09f7b49f.png">
fixes #480 