### PR TITLE
Added version and web warning to wallet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM node:lts-alpine AS builder
 
 WORKDIR /app
 COPY . .
-RUN npm install && npm run build
+RUN export WEB=true && npm install && npm run build
 
 FROM nginx:1.17-alpine AS runner
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/Vue.config-back.js
+++ b/Vue.config-back.js
@@ -1,5 +1,12 @@
 const path = require('path')
 
+// WAS THIS FILE WITH CAPITAL V USED????? NOTHING BELOW IS CONSOLED OUT!!
+
+const packageVersion = JSON.stringify(require('./package.json').version);
+const web = process.env.WEB || false;
+
+console.log(`Building package ${packageVersion} for Web: ${web}`);
+
 module.exports = {
   // base url
   publicPath: process.env.NODE_ENV === 'production'

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -1,5 +1,7 @@
 <template>
     <div id="app" class="mac">
+        <span class="web-warning-panel" v-if="web">{{ $t('web_wallet_warning') }}</span>
+        <div class="version-panel">{{ $t('version') }}: {{ packageVersion }}</div>
         <router-view />
         <DisabledUiOverlay />
         <SpinnerLoading v-if="hasLoadingOverlay" />

--- a/src/app/AppTs.ts
+++ b/src/app/AppTs.ts
@@ -34,14 +34,13 @@ import SpinnerLoading from '@/components/SpinnerLoading/SpinnerLoading.vue';
     },
 })
 export class AppTs extends Vue {
-
     /**
      * Display the application version. This is injected in the app when built.
      */
     public packageVersion = process.env.PACKAGE_VERSION || '0';
 
     /**
-     * Display the web wallet warning. This is injected in the app when built/
+     * Display the web wallet warning. This is injected in the app when built.
      */
     public web = process.env.WEB || false;
     /**
@@ -50,7 +49,6 @@ export class AppTs extends Vue {
      * @var {string}
      */
     public currentProfile: string;
-
 
     /**
      * Whether a loading overlay must be displayed

--- a/src/app/AppTs.ts
+++ b/src/app/AppTs.ts
@@ -34,12 +34,23 @@ import SpinnerLoading from '@/components/SpinnerLoading/SpinnerLoading.vue';
     },
 })
 export class AppTs extends Vue {
+
+    /**
+     * Display the application version. This is injected in the app when built.
+     */
+    public packageVersion = process.env.PACKAGE_VERSION || '0';
+
+    /**
+     * Display the web wallet warning. This is injected in the app when built/
+     */
+    public web = process.env.WEB || false;
     /**
      * Currently active profile
      * @see {Store.Profile}
      * @var {string}
      */
     public currentProfile: string;
+
 
     /**
      * Whether a loading overlay must be displayed

--- a/src/language/en-US.json
+++ b/src/language/en-US.json
@@ -663,6 +663,8 @@
     "verify_mnemonics": "Verify mnemonic words backup",
     "warning_already_a_cosignatory": "This account is already a cosignatory!",
     "welcome": "Welcome",
+    "version": "Version",
+    "web_wallet_warning": "This WEB wallet is for demonstration use only!",
     "word": "Word",
     "x_seconds": "{seconds}s."
 }

--- a/src/views/resources/css/common.less
+++ b/src/views/resources/css/common.less
@@ -438,3 +438,16 @@ button:disabled {
 .display-grid {
     display: grid;
 }
+.version-panel {
+    position: absolute;
+    right: 20px;
+    bottom: 7px;
+}
+
+.web-warning-panel {
+    position: absolute;
+    color: red;
+    font-weight: bold;
+    left: 120px;
+    bottom: 7px;
+}

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,21 @@
+const webpack = require('webpack');
+
+const packageVersion = JSON.stringify(require('./package.json').version);
+const web = process.env.WEB || false;
+
+console.log(`Building package ${packageVersion} for Web: ${web}`);
+
+module.exports = {
+    configureWebpack: () => {
+        return {
+            plugins: [
+                new webpack.DefinePlugin({
+                    'process.env': {
+                        PACKAGE_VERSION: packageVersion,
+                        WEB: web,
+                    },
+                }),
+            ],
+        };
+    },
+};


### PR DESCRIPTION
The current `Vue.config.js` file with capital V has a bunch of configurations that I don't think they are used. The version `vue.config.js` I'm coming here only has the customization I need to inject the web flag and version. I think the wallet was using the default vue config without any customization.

https://cli.vuejs.org/config/#global-cli-config

@OlegMakarenko @rg911 @yilmazbahadir . Do you think the Vue.config.js file was used on linux/mac machines? Maybe on windows as they are case insensitive. 

To run in "Web" Mode

`export WEB=true && npm run dev`

An example of where I would put the banner and version:

![image](https://user-images.githubusercontent.com/5390558/96522819-a4669c00-124a-11eb-9cd7-91e1a7b86573.png). Please correct the text or the location if you don't like it. It's using absolute position atm. It works but not ideal, pretty old school. 

I wouldn't put a commit tag in the version. Once the version is released, it should be immutable. What happened in the last release is that the version wasn't upgraded automatically so the confusion.  I guess it was not done using Travis or "release" branch.

Fixes https://github.com/nemgrouplimited/symbol-desktop-wallet/issues/580
Fixes https://github.com/nemgrouplimited/symbol-desktop-wallet/issues/566