### PR TITLE
Alias display bug fix

### DIFF
--- a/src/components/AccountAliasDisplay/AccountAliasDisplay.vue
+++ b/src/components/AccountAliasDisplay/AccountAliasDisplay.vue
@@ -2,8 +2,8 @@
     <div class="account-detail-row-3cols">
         <span class="label">{{ $t('aliases') }}:</span>
         <div class="value account-aliases">
-            <span v-for="(alias, index) in accountAliases" :key="index">
-                {{ index === accountAliases.length - 1 ? `${alias}` : `${alias},` }}
+            <span v-for="(alias, index) in accountAliasNames" :key="index">
+                {{ index === accountAliasNames.length - 1 ? `${alias}` : `${alias},` }}
             </span>
         </div>
     </div>

--- a/src/components/AccountAliasDisplay/AccountAliasDisplayTs.ts
+++ b/src/components/AccountAliasDisplay/AccountAliasDisplayTs.ts
@@ -18,11 +18,11 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 import { mapGetters } from 'vuex';
 // internal dependencies
 import { AccountModel } from '@/core/database/entities/AccountModel';
-import { NamespaceModel } from '@/core/database/entities/NamespaceModel';
+import { AccountNames } from 'symbol-sdk';
 
 @Component({
     computed: mapGetters({
-        namespaces: 'namespace/namespaces',
+        currentAccountAliases: 'account/currentAccountAliases',
     }),
 })
 export class AccountAliasDisplayTs extends Vue {
@@ -31,19 +31,14 @@ export class AccountAliasDisplayTs extends Vue {
     /**
      * NamespaceModel
      */
-    protected namespaces: NamespaceModel[];
+    protected currentAccountAliases: AccountNames[];
 
-    get accountAliases(): string[] {
-        if (!this.namespaces || !this.account) {
+    get accountAliasNames(): string[] {
+        const names = this.currentAccountAliases.find((alias) => alias.address.plain() === this.account.address)?.names;
+        if (!this.currentAccountAliases || !this.account || !names) {
             return [];
+        } else {
+            return names.map((aliasName) => aliasName.name);
         }
-
-        // get the current account address
-        const address = this.account.address;
-
-        // return the current account aliases
-        return this.namespaces
-            .filter(({ aliasTargetAddressRawPlain }) => aliasTargetAddressRawPlain && aliasTargetAddressRawPlain === address)
-            .map(({ name, namespaceIdHex }) => name || namespaceIdHex);
     }
 }


### PR DESCRIPTION
- when namespace(s) owner !== linked account, the account aliases does not show properly.
- Added `currentAccountAliases` to the account store.
- Reset accountAliases when account switch / set