### PR TITLE
Fixed encrypt message bug for zero public key in known account.

### DIFF
--- a/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
+++ b/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
@@ -14,7 +14,6 @@
  *
  */
 import {
-    AccountInfo,
     Address,
     EncryptedMessage,
     Message,
@@ -27,6 +26,7 @@ import {
     TransferTransaction,
     UInt64,
     Account,
+    PublicAccount,
 } from 'symbol-sdk';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { mapGetters } from 'vuex';
@@ -192,7 +192,7 @@ export class FormTransferTransactionTs extends FormTransactionBase {
     /**
      * Current recipient account info
      */
-    private currentRecipient: AccountInfo;
+    private currentRecipient: PublicAccount;
 
     private encyptedMessage: Message;
 
@@ -574,7 +574,7 @@ export class FormTransferTransactionTs extends FormTransactionBase {
     onAccountUnlocked(account: Account): boolean {
         this.hasAccountUnlockModal = false;
         this.encyptedMessage = this.formItems.messagePlain
-            ? EncryptedMessage.create(this.formItems.messagePlain, this.currentRecipient.publicAccount, account.privateKey)
+            ? EncryptedMessage.create(this.formItems.messagePlain, this.currentRecipient, account.privateKey)
             : PlainMessage.create('');
         this.formItems.encryptMessage = true;
         return true;


### PR DESCRIPTION
When a new account added in the profile, the public key will not be recognized by the node until the account has outgoing transaction. The public key will show as '0000....'

This fix:
- Added checks in account store load current recipient action to check existing known account. If not find then call the remote API, 
- changed currentRecipient model type from AccountInfo to PublicAccount.