### PR TITLE
Message display bug

### DIFF
--- a/src/components/MessageDisplay/MessageDisplay.vue
+++ b/src/components/MessageDisplay/MessageDisplay.vue
@@ -1,5 +1,5 @@
 <template>
-    <FormWrapper>
+    <FormWrapper :whitelisted="true">
         <div>
             <span>{{ messageDisplay }}</span>
             <span v-if="isEncrypted && !unannounced">

--- a/src/components/MessageDisplay/MessageDisplayTs.ts
+++ b/src/components/MessageDisplay/MessageDisplayTs.ts
@@ -67,7 +67,6 @@ export class MessageDisplayTs extends Vue {
     private decryptedMessage: PlainMessage;
     private currentRecipient: PublicAccount;
     private linkedAddress: Address | null;
-    private signerRecipient?: string;
     private currentAccount: AccountModel;
 
     /**
@@ -132,6 +131,11 @@ export class MessageDisplayTs extends Vue {
      * @param recipient: recipient address.
      */
     private decryptMessage(privateKey: string, recipient: Address) {
+        /**
+         * If transaction recipient === current account use signer to decrypt message
+         * Otherwise use the recipient for decryption
+         * */
+
         if (recipient.plain() === this.currentAccount.address) {
             this.decryptedMessage = EncryptedMessage.decrypt(this.message, privateKey, this.signer);
             this.isEncrypted = false;

--- a/src/components/TransactionDetails/TransactionDetailRow/TransactionDetailRow.vue
+++ b/src/components/TransactionDetails/TransactionDetailRow/TransactionDetailRow.vue
@@ -27,6 +27,7 @@
                     :incoming="item.value.incoming"
                     :recipient="item.value.recipient"
                     :unannounced="item.value.unannounced"
+                    :signer="item.value.signer"
                 />
             </span>
             <span v-else>

--- a/src/core/transactions/ViewTransferTransaction.ts
+++ b/src/core/transactions/ViewTransferTransaction.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
-import { TransferTransaction } from 'symbol-sdk';
+import { PublicAccount, TransferTransaction } from 'symbol-sdk';
 // internal dependencies
 import { TransactionView } from './TransactionView';
 import { AttachedMosaic } from '@/services/MosaicService';
@@ -96,6 +96,9 @@ export class ViewTransferTransaction extends TransactionView<TransferTransaction
                     incoming: this.isIncoming,
                     recipient: this.transaction.recipientAddress,
                     unannounced: this.transaction.isUnannounced(),
+                    signer: this.transaction.signer
+                        ? PublicAccount.createFromPublicKey(this.transaction.signer.publicKey, this.transaction.networkType)
+                        : null,
                 },
                 isMessage: true,
             },


### PR DESCRIPTION
Fixed:
- Decrypting messages should check the current account. If currentAccount = tx.recipient, then use the signer's public key to decrypt the message. otherwise, use the tx.recipient.
- MessageDisplay component has been added to the whitelist of DisabledFormOverlay. So that multisig account can decrypt messages.