### PR TITLE
Disable OSX build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ node_js:
   - 12
 os:
   - linux
-  - osx
-osx_image: xcode11.3
 env:
   global:
     - ELECTRON_CACHE=$HOME/.cache/electron
@@ -25,30 +23,29 @@ jobs:
     - stage: test
       name: lint tests
       script: npm run lint
-      os: linux
 
     - name: unit tests
       script: npm run test
-      os: osx
 
     - stage: alpha
       name: publish alpha docker
       script: /bin/sh travis/docker.sh
-      if: branch = env(DEV_BRANCH) AND type != pull_request AND (commit_message != release OR env(RELEASE_BRANCH) != env(DEV_BRANCH))
-      os: linux
+      if: branch = env(DEV_BRANCH) AND type = push
 
-    - script: npm run release:all
-      name: build desktop artifacts
-      if:  branch = env(DEV_BRANCH) AND type != pull_request AND (commit_message != release OR env(RELEASE_BRANCH) != env(DEV_BRANCH))
-      os: osx
+    - script: npm run release:lin
+      name: build linux desktop artifacts
+      if: branch = env(DEV_BRANCH) AND type = push
+
+    - script: npm run release:win
+      name: build win desktop artifacts
+      if: branch = env(DEV_BRANCH) AND type = push
 
     - stage: release
       name: release docker
       script: /bin/sh travis/docker.sh
-      if: branch = env(RELEASE_BRANCH) AND type != pull_request AND (commit_message = release OR env(RELEASE_BRANCH) != env(DEV_BRANCH))
+      if: branch = env(RELEASE_BRANCH) AND type = api AND commit_message = env(RELEASE_MESSAGE)
       os: linux
 
     - name: release desktop artifacts, tag and update version
       script: /bin/sh travis/release.sh
-      if: branch = env(RELEASE_BRANCH) AND type != pull_request AND (commit_message = release OR env(RELEASE_BRANCH) != env(DEV_BRANCH))
-      os: osx
+      if: branch = env(RELEASE_BRANCH) AND type = api AND commit_message = env(RELEASE_MESSAGE)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "build": "npm run build:web",
         "build:web": "rimraf dist && mkdir dist && tsc && vue-cli-service build",
         "release": "npm run build && npm run release:all",
-        "release:all": "npm run release:mac && npm run release:win && npm run release:lin",
+        "release:all": "npm run release:win && npm run release:lin",
         "release:mac": "electron-builder --mac",
         "release:win": "electron-builder --win",
         "release:lin": "electron-builder --linux deb snap tar.xz",


### PR DESCRIPTION
This PR disabled the OSX builds from for Travis to save cost. OSX is not free anymore in Travis for open source projects.

Let see if this re-enables the wallet builds on Travis.

The release:all excludes osx. One solution we could do is doing the release with Travis for all OSs but OSX. Once we do the release we can:

1) Run a release:lin release from a dev computer with mac and upload the artifacts to the (travis created) github release.
2) Create a special osx Travis job that only runs for building mac on release.  We would only be paying the osx cost when releasing. 