### PR TITLE
v0.13.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.13.4][v0.13.4] - 11-Nov-2020
+
+### Milestone: [catapult-server@v0.10.x](https://github.com/nemtech/catapult-server/releases/tag/v0.10.0.4)
+
+#### Fixed
+
+- Fixed delegated harvesting activation iseue.
+- Added existing NGL harvesting nodes to delegated harvesting node selector for function preview purposes.
+- UI fixed on delegated harvesting activation cofirmation page.
+
 ## [0.13.3][v0.13.3] - 09-Nov-2020
 
 ### Milestone: [catapult-server@v0.10.x](https://github.com/nemtech/catapult-server/releases/tag/v0.10.0.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 #### Fixed
 
-- Fixed delegated harvesting activation iseue.
+- Fixed delegated harvesting activation issues.
 - Added existing NGL harvesting nodes to delegated harvesting node selector for function preview purposes.
-- UI fixed on delegated harvesting activation cofirmation page.
+- UI fixed on the delegated harvesting activation confirmation page.
 
 ## [0.13.3][v0.13.3] - 09-Nov-2020
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "symbol-desktop-wallet",
-    "version": "0.13.3",
+    "version": "0.13.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "symbol-desktop-wallet",
     "description": "Symbol Wallet",
     "homepage": "https://github.com/nemgrouplimited/symbol-desktop-wallet",
-    "version": "0.13.3",
+    "version": "0.13.4",
     "repository": {
         "type": "git",
         "url": "https://github.com/nemgrouplimited/symbol-desktop-wallet.git"


### PR DESCRIPTION
## [0.13.4][v0.13.4] - 11-Nov-2020

### Milestone: [catapult-server@v0.10.x](https://github.com/nemtech/catapult-server/releases/tag/v0.10.0.4)

#### Fixed

- Fixed delegated harvesting activation issues.
- Added existing NGL harvesting nodes to delegated harvesting node selector for function preview purposes.
- UI fixed on the delegated harvesting activation confirmation page.