### PR TITLE
Fix delete account critical bug

### DIFF
--- a/src/components/AccountSelectorPanel/AccountSelectorPanel.vue
+++ b/src/components/AccountSelectorPanel/AccountSelectorPanel.vue
@@ -3,8 +3,8 @@
         <div v-auto-scroll="'active-background'" class="account-switch-body-container scroll">
             <div class="account-type-title">Seed accounts</div>
             <div
-                v-for="(item, index) in seedAccounts"
-                :key="index"
+                v-for="item in seedAccounts"
+                :key="item.id"
                 :class="['account-tile', isActiveAccount(item) ? 'active-background' : 'inactive-background', 'pointer']"
                 @click="currentAccountIdentifier = item.id"
             >
@@ -24,8 +24,8 @@
             </div>
             <div v-if="pkAccounts.length > 0" class="account-type-title">Private key accounts</div>
             <div
-                v-for="(item, index) in pkAccounts"
-                :key="index"
+                v-for="item in pkAccounts"
+                :key="item.id"
                 :class="['account-tile', isActiveAccount(item) ? 'active-background' : 'inactive-background', 'pointer']"
                 @click="currentAccountIdentifier = item.id"
             >

--- a/src/language/en-US.json
+++ b/src/language/en-US.json
@@ -429,6 +429,7 @@
     "modal_title_transaction_confirmation": "Sign transaction(s)",
     "modal_title_transaction_details": "Details about a transaction",
     "modal_title_unlink_alias": "Unlink alias from namespace",
+    "modal_title_delete": "Delete confirmation",
     "more_access_tool_is_working": "More authentication tools are being worked on...",
     "mosaic": "Mosaic",
     "mosaic_alias_not_exist": "Mosaic alias does not exist",

--- a/src/language/ja-JP.json
+++ b/src/language/ja-JP.json
@@ -429,6 +429,7 @@
     "modal_title_transaction_confirmation": "トランザクション(s)に署名",
     "modal_title_transaction_details": "トランザクション詳細",
     "modal_title_unlink_alias": "エイリアスをネームスペースからアンリンク",
+    "modal_title_delete": "確認を削除する",
     "more_access_tool_is_working": "たくさんの認証ツールを開発中です",
     "mosaic": "モザイク",
     "mosaic_alias_not_exist": "モザイクエイリアスは存在しません",

--- a/src/language/zh-CN.json
+++ b/src/language/zh-CN.json
@@ -429,6 +429,7 @@
     "modal_title_transaction_confirmation": "签署交易",
     "modal_title_transaction_details": "交易详情",
     "modal_title_unlink_alias": "取消别名与命名空间的链接",
+    "modal_title_delete": "删除确认",
     "more_access_tool_is_working": "更多接入方式正在开发中",
     "mosaic": "马赛克",
     "mosaic_alias_not_exist": "马赛克别名不存在",

--- a/src/store/Account.ts
+++ b/src/store/Account.ts
@@ -567,7 +567,7 @@ export default {
             }
             const accountService = new AccountService();
             accountService.deleteAccount(account);
-            const accountsIds = accountService.getAccounts().map((acc) => acc.id);
+            const accountsIds = accountService.getAccounts().filter(acc => acc.profileName === currentProfile.profileName).map((acc) => acc.id);
             // update accounts in profile
             new ProfileService().updateAccounts(currentProfile, [...accountsIds]);
             // set first account to be selected

--- a/src/store/Account.ts
+++ b/src/store/Account.ts
@@ -567,7 +567,10 @@ export default {
             }
             const accountService = new AccountService();
             accountService.deleteAccount(account);
-            const accountsIds = accountService.getAccounts().filter(acc => acc.profileName === currentProfile.profileName).map((acc) => acc.id);
+            const accountsIds = accountService
+                .getAccounts()
+                .filter((acc) => acc.profileName === currentProfile.profileName)
+                .map((acc) => acc.id);
             // update accounts in profile
             new ProfileService().updateAccounts(currentProfile, [...accountsIds]);
             // set first account to be selected

--- a/src/views/modals/ModalConfirmDelete/ModalConfirmDelete.vue
+++ b/src/views/modals/ModalConfirmDelete/ModalConfirmDelete.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="container">
-        <Modal v-model="show" class-name="modal-container" :title="$t('modal_title_enter_account_name')" :transfer="false">
+        <Modal v-model="show" class-name="modal-container" :title="$t('modal_title_delete')" :transfer="false">
             {{ $t('delete_confirmation_message') }}
             <button type="submit" class="position centered-button button-style inverted-button pl-2 pr-2" @click="confirm">
                 {{ $t('confirm') }}


### PR DESCRIPTION
Critical bug when deleting accounts.

The store was looking at all the accounts without filtering them by the selected profile. After that it was updating the accounts to point the current profile.