### PR TITLE
AddressQR and ContactQR changed to base on QRDisplay component, minor styling fixes

### DIFF
--- a/src/components/AccountContactQR/AccountContactQR.vue
+++ b/src/components/AccountContactQR/AccountContactQR.vue
@@ -1,14 +1,6 @@
 <template>
     <div>
-        <div class="clearfix centered">
-            <img class="qr-code-image" :src="qrCode$" />
-        </div>
-        <div class="clearfix centered">
-            <span class="qr-code-title">{{ $t('address_qr_code') }}</span>
-        </div>
-        <div class="clearfix centered">
-            <a :href="qrCode$" :download="downloadName">{{ $t('button_download_qr') }}</a>
-        </div>
+        <QRCodeDisplay :qr-code="qrCodeArgs" show-download="true" header="address_qr_code" :download-name="downloadName" />
     </div>
 </template>
 
@@ -16,22 +8,3 @@
 import { AccountContactQRTs } from './AccountContactQRTs';
 export default class AccountContactQR extends AccountContactQRTs {}
 </script>
-
-<style lang="less" scoped>
-@import '../../views/resources/css/variables.less';
-.centered {
-    text-align: center;
-}
-
-.qr-code-title {
-    font-size: 16px;
-    text-align: center;
-    font-weight: 400;
-    color: @primary;
-}
-
-.qr-code-image {
-    width: 2rem;
-    height: 2rem;
-}
-</style>

--- a/src/components/AccountContactQR/AccountContactQRTs.ts
+++ b/src/components/AccountContactQR/AccountContactQRTs.ts
@@ -16,34 +16,20 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { ContactQR } from 'symbol-qr-library';
 import { PublicAccount } from 'symbol-sdk';
-import { Observable, of } from 'rxjs';
-import { concatMap, pluck } from 'rxjs/operators';
 // internal dependencies
 import { AccountModel } from '@/core/database/entities/AccountModel';
 // resources
-// @ts-ignore
-import failureIcon from '@/views/resources/img/monitor/failure.png';
 import { mapGetters } from 'vuex';
-
+// @ts-ignore
+import QRCodeDisplay from '@/components/QRCode/QRCodeDisplay/QRCodeDisplay.vue';
 @Component({
+    components: {
+        QRCodeDisplay,
+    },
     computed: {
         ...mapGetters({
             generationHash: 'network/generationHash',
         }),
-    },
-    subscriptions() {
-        const qrCode$ = this.$watchAsObservable('qrCodeArgs', {
-            immediate: true,
-        }).pipe(
-            pluck('newValue'),
-            concatMap((args) => {
-                if (args instanceof ContactQR) {
-                    return args.toBase64();
-                }
-                return of(failureIcon);
-            }),
-        );
-        return { qrCode$ };
     },
 })
 export class AccountContactQRTs extends Vue {
@@ -57,12 +43,6 @@ export class AccountContactQRTs extends Vue {
      * @var {string}
      */
     public generationHash: string;
-
-    /**
-     * QR Code
-     * @type {Observable<string>}
-     */
-    public qrCode$: Observable<string>;
 
     /// region computed properties getter/setter
     get qrCodeArgs(): ContactQR {

--- a/src/components/AddressQR/AddressQR.vue
+++ b/src/components/AddressQR/AddressQR.vue
@@ -1,14 +1,6 @@
 <template>
     <div>
-        <div class="clearfix centered">
-            <img class="qr-code-image" :src="qrCode$" />
-        </div>
-        <div class="clearfix centered">
-            <span class="qr-code-title">{{ $t('contact_qr_code') }}</span>
-        </div>
-        <div class="clearfix centered">
-            <a :href="qrCode$" :download="downloadName">{{ $t('button_download_qr') }}</a>
-        </div>
+        <QRCodeDisplay :qr-code="qrCodeArgs" show-download="true" header="contact_qr_code" :download-name="downloadName" />
     </div>
 </template>
 
@@ -16,22 +8,3 @@
 import { AddressQRTs } from './AddressQRTs';
 export default class AddressQR extends AddressQRTs {}
 </script>
-
-<style lang="less" scoped>
-@import '../../views/resources/css/variables.less';
-.centered {
-    text-align: center;
-}
-
-.qr-code-title {
-    font-size: 16px;
-    text-align: center;
-    font-weight: 400;
-    color: @grayDark;
-}
-
-.qr-code-image {
-    width: 2rem;
-    height: 2rem;
-}
-</style>

--- a/src/components/AddressQR/AddressQRTs.ts
+++ b/src/components/AddressQR/AddressQRTs.ts
@@ -16,33 +16,18 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { AddressQR } from 'symbol-qr-library';
 import { Address } from 'symbol-sdk';
-import { Observable, of } from 'rxjs';
-import { concatMap, pluck } from 'rxjs/operators';
-// resources
-// @ts-ignore
-import failureIcon from '@/views/resources/img/monitor/failure.png';
 import { mapGetters } from 'vuex';
 import { IContact } from 'symbol-address-book';
-
+// @ts-ignore
+import QRCodeDisplay from '@/components/QRCode/QRCodeDisplay/QRCodeDisplay.vue';
 @Component({
+    components: {
+        QRCodeDisplay,
+    },
     computed: {
         ...mapGetters({
             generationHash: 'network/generationHash',
         }),
-    },
-    subscriptions() {
-        const qrCode$ = this.$watchAsObservable('qrCodeArgs', {
-            immediate: true,
-        }).pipe(
-            pluck('newValue'),
-            concatMap((args) => {
-                if (args instanceof AddressQR) {
-                    return args.toBase64();
-                }
-                return of(failureIcon);
-            }),
-        );
-        return { qrCode$ };
     },
 })
 export class AddressQRTs extends Vue {
@@ -56,12 +41,6 @@ export class AddressQRTs extends Vue {
      * @var {string}
      */
     public generationHash: string;
-
-    /**
-     * QR Code
-     * @type {Observable<string>}
-     */
-    public qrCode$: Observable<string>;
 
     /// region computed properties getter/setter
     get qrCodeArgs(): AddressQR {

--- a/src/components/NetworkNodeSelector/NetworkNodeSelector.less
+++ b/src/components/NetworkNodeSelector/NetworkNodeSelector.less
@@ -8,5 +8,5 @@
 
 .publickey-input-container {
     background: #f2f2f2;
-    margin-top: 0.04rem;
+    margin-top: 0.14rem;
 }

--- a/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransaction.less
+++ b/src/views/forms/FormPersistentDelegationRequestTransaction/FormPersistentDelegationRequestTransaction.less
@@ -77,5 +77,5 @@
 }
 
 .buttons-row {
-    margin-top: 0.3rem;
+    margin-top: 0.6rem;
 }


### PR DESCRIPTION
In order to present the user same look and feel for every QR we present, AddressQR and ContactQR view components should be based on the QRDisplay component we already have. Please see the result image below.

![Screenshot 2020-11-19 at 08 40 23](https://user-images.githubusercontent.com/6256269/99642051-f6b1fd00-2a42-11eb-9a20-45f64c5a9bb3.png)
