### PR TITLE
clean up unused harvesting fields after migrating to HarvestingModel

### DIFF
--- a/src/core/database/entities/AccountModel.ts
+++ b/src/core/database/entities/AccountModel.ts
@@ -55,9 +55,7 @@ export class AccountModel {
     public readonly path: string;
     public readonly isMultisig: boolean;
     public readonly encRemoteAccountPrivateKey?: string;
-    public readonly signedPersistentDelReqTxs?: SignedTransaction[];
-    public readonly isPersistentDelReqSent?: boolean;
-    public readonly selectedHarvestingNode?: NodeModel;
+
     /**
      * Permits to return specific field's mapped object instances
      * @return any

--- a/src/store/Harvesting.ts
+++ b/src/store/Harvesting.ts
@@ -138,7 +138,7 @@ export default {
             if (!currentSignerAccountInfo) {
                 return;
             }
-            const currentSignerHarvestingModel: AccountModel = rootGetters['harvesting/currentSignerHarvestingModel'];
+            const currentSignerHarvestingModel: HarvestingModel = rootGetters['harvesting/currentSignerHarvestingModel'];
             let accountUnlocked = false;
 
             if (currentSignerHarvestingModel) {


### PR DESCRIPTION
After migrating to HarvestingModel, it is time to clean up the unused fields on AccountModel.