### PR TITLE
v0.13.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,41 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.13.6][v0.13.6] - 11-Dec-2020
+
+### Milestone: [catapult-server@v0.10.x](https://github.com/nemtech/catapult-server/releases/tag/v0.10.0.4)
+
+#### Added
+
+- Added Account Restrictions feature (add and delete restrictions), includes the following types: 
+  - Address Restrictions
+  - Mosaic Restrictions
+  - Operation(Transaction Type) Restrictions
+- Added cross-platform zip artifact release
+  - Allows opening directly index.html in the browser (after unzipping the archive file)
+- Added account metadata transaction update feature
+- Added confirmation modal (with warning) after the delete account button is clicked
+#### Fixed
+
+- Fixed multisig account sends transaction issue.
+- Fixed NodeSelector to filter nodes with role type 'peer'.
+  - Until the mainnet release we will keep the static node list(starts with 'beacon') added on top of the dynamic list.
+- Fixed ContactQR publickey bug on export (Import QR Code, next button missing #725).
+- Fixed required-cosignature count bug on metadata transaction.
+- Fixed target account to the selected signer for mosaic and namespace metadata and removed from the forms.
+- Fixed coins transfered from co-signers instead of multi-sig account issue.
+- Fixed harvesting with multi-sig account on different profile issue.
+- Fixed missing add button in aggregate transactions
+- Fixed show notification in case mnemonic not valid before going to next step
+- Fixed AddressQR and ContactQR to use the same QRDisplay component.
+- Fixed overflow on Transaction Modal.
+- Fixed translation issues (especially Japaneese).
+- Improved multi-sig graph view on Account Details Page and Aliases display.
+- UI fixes 
+  - Fixed unable to add json Address Book after attaching invalid format file issue.
+  - Fixed select contact window issues.
+  - Fixed fee selector is not visible issue on modify mosaic supply modal.
+  - Fixed empty window after logout issue.
 ## [0.13.5][v0.13.5] - 18-Nov-2020
 
 ### Milestone: [catapult-server@v0.10.x](https://github.com/nemtech/catapult-server/releases/tag/v0.10.0.4)
@@ -399,6 +434,7 @@ NOTE: We have known issues which have been logged into github and will look for 
 - Missing harvesting setup (account link & persistent delegation requests)
 - Some missing UI fixes for Symbol rebrand
 
+[v0.13.6]: https://github.com/nemfoundation/symbol-desktop-wallet/releases/tag/v0.13.5...v0.13.6
 [v0.13.5]: https://github.com/nemfoundation/symbol-desktop-wallet/releases/tag/v0.13.4...v0.13.5
 [v0.13.4]: https://github.com/nemfoundation/symbol-desktop-wallet/releases/tag/v0.13.3...v0.13.4
 [v0.13.3]: https://github.com/nemfoundation/symbol-desktop-wallet/releases/tag/v0.13.3...v0.13.3

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "symbol-desktop-wallet",
     "description": "Symbol Wallet",
     "homepage": "https://github.com/nemgrouplimited/symbol-desktop-wallet",
-    "version": "0.13.5",
+    "version": "0.13.6",
     "repository": {
         "type": "git",
         "url": "https://github.com/nemgrouplimited/symbol-desktop-wallet.git"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "build": "npm run build:web",
         "build:web": "rimraf dist && mkdir dist && tsc && vue-cli-service build",
         "release": "npm run build && npm run release:all",
-        "release:all": "npm run release:win && npm run release:lin && npm run release:zip",
+        "release:all": "npm run release:win && npm run release:lin && npm run release:mac && npm run release:zip",
         "release:mac": "electron-builder --mac",
         "release:win": "electron-builder --win",
         "release:lin": "electron-builder --linux deb snap tar.xz",

--- a/src/config/NetworkConfig.ts
+++ b/src/config/NetworkConfig.ts
@@ -53,7 +53,7 @@ const defaultNetworkConfig: NetworkConfig = {
     explorerUrl: 'http://explorer-0.10.0.x-01.symboldev.network/',
     faucetUrl: 'http://faucet-0.10.0.x-01.symboldev.network/',
     defaultNetworkType: 152,
-    defaultNodeUrl: 'http://api-01.us-east-1.0.10.0.x.symboldev.network:3000',
+    defaultNodeUrl: 'http://api-01.us-west-1.0.10.0.x.symboldev.network:3000',
     networkConfigurationDefaults: {
         maxMosaicDivisibility: 6,
         namespaceGracePeriodDuration: 2592000,
@@ -76,7 +76,7 @@ const defaultNetworkConfig: NetworkConfig = {
     nodes: [
         { friendlyName: 'API EU Central 1', roles: 2, url: 'http://api-01.eu-central-1.0.10.0.x.symboldev.network:3000' },
         { friendlyName: 'API EU West 1', roles: 2, url: 'http://api-01.eu-west-1.0.10.0.x.symboldev.network:3000' },
-        { friendlyName: 'API US East 1', roles: 2, url: 'http://api-01.us-east-1.0.10.0.x.symboldev.network:3000' },
+        // { friendlyName: 'API US East 1', roles: 2, url: 'http://api-01.us-east-1.0.10.0.x.symboldev.network:3000' },
         { friendlyName: 'API US West 1', roles: 2, url: 'http://api-01.us-west-1.0.10.0.x.symboldev.network:3000' },
         { friendlyName: 'API US West 2', roles: 2, url: 'http://api-01.us-west-2.0.10.0.x.symboldev.network:3000' },
         {

--- a/src/core/database/entities/AccountModel.ts
+++ b/src/core/database/entities/AccountModel.ts
@@ -14,8 +14,7 @@
  *
  */
 
-import { Address, PublicAccount, SignedTransaction } from 'symbol-sdk';
-import { NodeModel } from './NodeModel';
+import { Address, PublicAccount } from 'symbol-sdk';
 
 export class AccountType {
     public static readonly SEED: number = 1;

--- a/src/core/database/storage/NetworkModelStorage.ts
+++ b/src/core/database/storage/NetworkModelStorage.ts
@@ -84,6 +84,38 @@ export class NetworkModelStorage extends VersionedNetworkBasedObjectStorage<Netw
                     return modified;
                 },
             },
+            {
+                description: 'Update networkCache for default node url change',
+                migrate: (from: any) => {
+                    const modified: any = from;
+                    const url = modified['6C1B92391CCB41C96478471C2634C111D9E989DECD66130C0430B5B8D20117CD'].data.url;
+                    console.log('here is the url:' + url);
+
+                    if (url?.startsWith('http://api-01.us-east-1.0.10.0.x.symboldev.network:3000')) {
+                        // update URL and nodeInfo
+                        modified['6C1B92391CCB41C96478471C2634C111D9E989DECD66130C0430B5B8D20117CD'] = new NetworkModel(
+                            'http://api-01.us-west-1.0.10.0.x.symboldev.network:3000',
+                            NetworkType.TEST_NET,
+                            '6C1B92391CCB41C96478471C2634C111D9E989DECD66130C0430B5B8D20117CD',
+                            networkConfig.networkConfigurationDefaults,
+                            new TransactionFees(3, 0, 1000, 0),
+                            new NodeInfo(
+                                'F5A8DA4CB59AA234A0A1CB62AEEC508AD9A3D4EBD5946BE2BCCCCAB111AF199C',
+                                '6C1B92391CCB41C96478471C2634C111D9E989DECD66130C0430B5B8D20117CD',
+                                7900,
+                                NetworkType.TEST_NET,
+                                0,
+                                [RoleType.PeerNode, RoleType.ApiNode, RoleType.VotingNode],
+                                '',
+                                'api-01-us-west-1',
+                                'F9E8648B88F2119328E75A0F1F8B4A7F83ED586DEC9DD2F5CD5D9D96BE48F0BE',
+                            ),
+                        );
+                    }
+
+                    return modified;
+                },
+            },
         ]);
     }
 }

--- a/src/store/Harvesting.ts
+++ b/src/store/Harvesting.ts
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and limitations under the License.
  *
  */
+import { HarvestingModel } from '@/core/database/entities/HarvestingModel';
+import { NodeModel } from '@/core/database/entities/NodeModel';
+import { URLHelpers } from '@/core/utils/URLHelpers';
+import { HarvestingService } from '@/services/HarvestingService';
+import { PageInfo } from '@/store/Transaction';
+import { map, reduce } from 'rxjs/operators';
 import {
     AccountInfo,
     Address,
@@ -26,15 +32,8 @@ import {
     UInt64,
 } from 'symbol-sdk';
 import Vue from 'vue';
-import { map, reduce } from 'rxjs/operators';
 // internal dependencies
 import { AwaitLock } from './AwaitLock';
-import { PageInfo } from '@/store/Transaction';
-import { AccountModel } from '@/core/database/entities/AccountModel';
-import { URLHelpers } from '@/core/utils/URLHelpers';
-import { HarvestingModel } from '@/core/database/entities/HarvestingModel';
-import { HarvestingService } from '@/services/HarvestingService';
-import { NodeModel } from '@/core/database/entities/NodeModel';
 
 const Lock = AwaitLock.create();
 


### PR DESCRIPTION
## [0.13.6][v0.13.6] - 11-Dec-2020

### Milestone: [catapult-server@v0.10.x](https://github.com/nemtech/catapult-server/releases/tag/v0.10.0.4)

#### Added

- Added Account Restrictions feature (add and delete restrictions), includes the following types: 
  - Address Restrictions
  - Mosaic Restrictions
  - Operation(Transaction Type) Restrictions
- Added cross-platform zip artifact release
  - Allows opening directly index.html in the browser (after unzipping the archive file)
- Added account metadata transaction update feature
- Added confirmation modal (with warning) after the delete account button is clicked
#### Fixed

- Fixed multisig account sends transaction issue.
- Fixed NodeSelector to filter nodes with role type 'peer'.
  - Until the mainnet release we will keep the static node list(starts with 'beacon') added on top of the dynamic list.
- Fixed ContactQR publickey bug on export (Import QR Code, next button missing #725).
- Fixed required-cosignature count bug on metadata transaction.
- Fixed target account to the selected signer for mosaic and namespace metadata and removed from the forms.
- Fixed coins transfered from co-signers instead of multi-sig account issue.
- Fixed harvesting with multi-sig account on different profile issue.
- Fixed missing add button in aggregate transactions
- Fixed show notification in case mnemonic not valid before going to next step
- Fixed AddressQR and ContactQR to use the same QRDisplay component.
- Fixed overflow on Transaction Modal.
- Fixed translation issues (especially Japaneese).
- Improved multi-sig graph view on Account Details Page and Aliases display.
- UI fixes 
  - Fixed unable to add json Address Book after attaching invalid format file issue.
  - Fixed select contact window issues.
  - Fixed fee selector is not visible issue on modify mosaic supply modal.
  - Fixed empty window after logout issue.