### PR TITLE
fix bug cannot lift restriction

### DIFF
--- a/src/components/TransactionTypeSelector/TransactionTypeSelectorTs.ts
+++ b/src/components/TransactionTypeSelector/TransactionTypeSelectorTs.ts
@@ -47,7 +47,7 @@ export default class TransactionTypeSelectorTs extends Vue {
      */
     public get transactionTypeList() {
         return Object.entries(TransactionType)
-            .filter((e) => !(parseInt(e[0]) >= 0) && e[0] !== 'RESERVED')
+            .filter((e) => !(parseInt(e[0]) >= 0) && e[0] !== 'RESERVED' && e[1] !== TransactionType.ACCOUNT_OPERATION_RESTRICTION)
             .sort((e1, e2) => e1[0].localeCompare(e2[0]));
     }
 }

--- a/src/views/forms/FormAccountRestrictionTransaction/FormAccountRestrictionTransaction.vue
+++ b/src/views/forms/FormAccountRestrictionTransaction/FormAccountRestrictionTransaction.vue
@@ -8,7 +8,10 @@
 
                     <RestrictionDirectionInput v-model="formItems.direction" :disabled="isDeleteMode || directionDisabled" />
 
-                    <RestrictionTypeInput v-model="formItems.blockType" :disabled="isDeleteMode || transactionTypeDisabled" />
+                    <RestrictionTypeInput
+                        v-model="formItems.blockType"
+                        :disabled="isDeleteMode || transactionTypeDisabled || restrictionTxType === 'TRANSACTION_TYPE'"
+                    />
 
                     <!-- Transfer recipient input field -->
                     <RecipientInput v-if="restrictionTxType === 'ADDRESS'" v-model="formItems.recipientRaw" :disabled="isDeleteMode" />

--- a/src/views/forms/FormAccountRestrictionTransaction/FormAccountRestrictionTransaction.vue
+++ b/src/views/forms/FormAccountRestrictionTransaction/FormAccountRestrictionTransaction.vue
@@ -8,10 +8,7 @@
 
                     <RestrictionDirectionInput v-model="formItems.direction" :disabled="isDeleteMode || directionDisabled" />
 
-                    <RestrictionTypeInput
-                        v-model="formItems.blockType"
-                        :disabled="isDeleteMode || transactionTypeDisabled || restrictionTxType === 'TRANSACTION_TYPE'"
-                    />
+                    <RestrictionTypeInput v-model="formItems.blockType" :disabled="isDeleteMode || transactionTypeDisabled" />
 
                     <!-- Transfer recipient input field -->
                     <RecipientInput v-if="restrictionTxType === 'ADDRESS'" v-model="formItems.recipientRaw" :disabled="isDeleteMode" />

--- a/src/views/forms/FormAccountRestrictionTransaction/FormAccountRestrictionTransactionTs.ts
+++ b/src/views/forms/FormAccountRestrictionTransaction/FormAccountRestrictionTransactionTs.ts
@@ -253,8 +253,10 @@ export class FormAccountRestrictionTransactionTs extends FormTransactionBase {
             restrictions = this.accountOperationRestrictions;
         }
 
-        if (restrictions?.length > 0) {
-            this.formItems.blockType = RestrictionFlagMapping.toBlockType(restrictions[0].restrictionFlags);
+        if (restrictions?.length > 0 || this.restrictionTxType === AccountRestrictionTxType.TRANSACTION_TYPE) {
+            if (restrictions[0]) {
+                this.formItems.blockType = RestrictionFlagMapping.toBlockType(restrictions[0].restrictionFlags);
+            }
             return true;
         }
         return false;

--- a/src/views/forms/FormAccountRestrictionTransaction/RestrictionFlagMapping.ts
+++ b/src/views/forms/FormAccountRestrictionTransaction/RestrictionFlagMapping.ts
@@ -56,11 +56,7 @@ export default class RestrictionFlagMapping {
                     return MosaicRestrictionFlag.AllowMosaic;
                 }
             case AccountRestrictionTxType.TRANSACTION_TYPE:
-                if (blockType === RestrictionBlockType.BLOCK) {
-                    return OperationRestrictionFlag.BlockOutgoingTransactionType;
-                } else {
-                    return OperationRestrictionFlag.AllowOutgoingTransactionType;
-                }
+                return OperationRestrictionFlag.BlockOutgoingTransactionType;
         }
     }
 


### PR DESCRIPTION
- Issues Fixed:
#808 #807 #811

- After discussion with @cryptoBeliever and @yilmazbahadir on account restrictions issues on wallet we concluded that the solution to tackle them so far on client-side could happen by modifying couple of things : 

1.  Eliminate Account Operation Restriction from operation types, so users are not able to use it either to block or allow that specific type.

2. All the other operation restriction types only block would be allowed.