### PR TITLE
v 0.13.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,40 +7,36 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ### Milestone: [catapult-server@v0.10.x](https://github.com/nemtech/catapult-server/releases/tag/v0.10.0.4)
 
 #### Added
-
-- Add URL validation procedure to the web-contents-created callback  to avoid remote code execution attacks.
-- Added pop-up when co-signatory address is not valid in multisig page.
+- Add URL validation procedure to the web-contents-created callback to avoid remote code execution attacks.
+- Added pop-up when co-signatory address is not valid on multisig page.
 - Added icon for NODE_KEY_LINK transactions.
-(**BREAKING CHANGE**)
-- Added minFeeMultiplier to support the new catapult-server minimal fee requirement.
-
+- added minFeeMultiplier to support the new catapult-server minimal fee requirement.
 #### Fixed
-
 - Improve Japanese translation.
-- Fixed validation for duplicates in contact creation .
+- Fixed validation for duplicates in contact creation.
 - Removed additional space in Select Contact window
 - Fixed visibility for balance in profile import form.
 - Updated Electron.
 - Updated feeds to use HTTPS to avoid potential content spoofing.
-- Fixed import account stucks at Mnemonic Passphrase stage.
-- Fixed validation in contact form.
+- Fixed import account stalls at Mnemonic Passphrase stage.
+- Fixed validation in the contact form.
 - Removed Foundation tags.
 - Fixed transaction filter is not closed after clicking outside the dropdown.
 - Fixed UI issue in Account Restrictions.
-  - Button New Address Restriction is out of window.
+  - Button New Address Restriction is out of the window.
   - Button Cancel is out of the window.
-  - Address/ Mosaic deletion window doesn't disappear when restriction was removed.
-  - Multisig account is not fully visible on address restriction page.
+  - Address/ Mosaic deletion window doesn't disappear when the restriction was removed.
+  - Multisig account is not fully visible on the address restriction page.
 - Fixed not all the Aggregate page is inactive under Multisig account.
 - Fixed carriage in "To" field for Simple transaction under Multisig account via Aggregate.
 - Fixed single character namespace creation is disabled.
 - Fixed note not visible with normal window size in all transaction forms.
-- Fixed import Transaction URI" dialog window has wrong size.
-- Fixed unable to convert account to multi-signature
-- Fixed unablity of converting account to multisig
+- Fixed import Transaction URI" dialog window has the wrong size.
+- Fixed unable to convert the account to multi-signature
+- Fixed inability of converting the account to multisig
 - Fixed mnemonic for password backup is always displayed as invalid.
 - Fixed "Add a cosignatory" button missing on Multisig page after toggling from co-signer to not co-signer via upper menu.
-- Fixed setting form url update state.
+- Fixed setting form URL update state.
 - Fixed mnemonic issues.
 - Fixed UI bugs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+## [0.13.7][v0.13.7] - 15-Jan-2020
+
+### Milestone: [catapult-server@v0.10.x](https://github.com/nemtech/catapult-server/releases/tag/v0.10.0.4)
+
+#### Added
+
+- Add URL validation procedure to the web-contents-created callback  to avoid remote code execution attacks.
+- Added pop-up when co-signatory address is not valid in multisig page.
+- Added icon for NODE_KEY_LINK transactions.
+(**BREAKING CHANGE**)
+- Added minFeeMultiplier to support the new catapult-server minimal fee requirement.
+
+#### Fixed
+
+- Improve Japanese translation.
+- Fixed validation for duplicates in contact creation .
+- Removed additional space in Select Contact window
+- Fixed visibility for balance in profile import form.
+- Updated Electron.
+- Updated feeds to use HTTPS to avoid potential content spoofing.
+- Fixed import account stucks at Mnemonic Passphrase stage.
+- Fixed validation in contact form.
+- Removed Foundation tags.
+- Fixed transaction filter is not closed after clicking outside the dropdown.
+- Fixed UI issue in Account Restrictions.
+  - Button New Address Restriction is out of window.
+  - Button Cancel is out of the window.
+  - Address/ Mosaic deletion window doesn't disappear when restriction was removed.
+  - Multisig account is not fully visible on address restriction page.
+- Fixed not all the Aggregate page is inactive under Multisig account.
+- Fixed carriage in "To" field for Simple transaction under Multisig account via Aggregate.
+- Fixed single character namespace creation is disabled.
+- Fixed note not visible with normal window size in all transaction forms.
+- Fixed import Transaction URI" dialog window has wrong size.
+- Fixed unable to convert account to multi-signature
+- Fixed unablity of converting account to multisig
+- Fixed mnemonic for password backup is always displayed as invalid.
+- Fixed "Add a cosignatory" button missing on Multisig page after toggling from co-signer to not co-signer via upper menu.
+- Fixed setting form url update state.
+- Fixed mnemonic issues.
+- Fixed UI bugs.
+
 
 ## [0.13.6][v0.13.6] - 11-Dec-2020
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7566,6 +7566,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
             "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -8395,14 +8396,6 @@
                     "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
                     "dev": true
                 }
-            }
-        },
-        "electron-localshortcut": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/electron-localshortcut/-/electron-localshortcut-3.2.1.tgz",
-            "integrity": "sha512-DWvhKv36GsdXKnaFFhEiK8kZZA+24/yFLgtTwJJHc7AFgDjNRIBJZ/jq62Y/dWv9E4ypYwrVWN2bVrCYw1uv7Q==",
-            "requires": {
-                "debug": "^4.0.1"
             }
         },
         "electron-notarize": {
@@ -14879,7 +14872,8 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "multicast-dns": {
             "version": "6.2.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "symbol-desktop-wallet",
     "description": "Symbol Wallet",
     "homepage": "https://github.com/nemgrouplimited/symbol-desktop-wallet",
-    "version": "0.13.6",
+    "version": "0.13.7",
     "repository": {
         "type": "git",
         "url": "https://github.com/nemgrouplimited/symbol-desktop-wallet.git"


### PR DESCRIPTION
#### Added
- Add URL validation procedure to the web-contents-created callback to avoid remote code execution attacks.
- Added pop-up when co-signatory address is not valid on multisig page.
- Added icon for NODE_KEY_LINK transactions.
- added minFeeMultiplier to support the new catapult-server minimal fee requirement.
#### Fixed
- Improve Japanese translation.
- Fixed validation for duplicates in contact creation.
- Removed additional space in Select Contact window
- Fixed visibility for balance in profile import form.
- Updated Electron.
- Updated feeds to use HTTPS to avoid potential content spoofing.
- Fixed import account stalls at Mnemonic Passphrase stage.
- Fixed validation in the contact form.
- Removed Foundation tags.
- Fixed transaction filter is not closed after clicking outside the dropdown.
- Fixed UI issue in Account Restrictions.
  - Button New Address Restriction is out of the window.
  - Button Cancel is out of the window.
  - Address/ Mosaic deletion window doesn't disappear when the restriction was removed.
  - Multisig account is not fully visible on the address restriction page.
- Fixed not all the Aggregate page is inactive under Multisig account.
- Fixed carriage in "To" field for Simple transaction under Multisig account via Aggregate.
- Fixed single character namespace creation is disabled.
- Fixed note not visible with normal window size in all transaction forms.
- Fixed import Transaction URI" dialog window has the wrong size.
- Fixed unable to convert the account to multi-signature
- Fixed inability of converting the account to multisig
- Fixed mnemonic for password backup is always displayed as invalid.
- Fixed "Add a cosignatory" button missing on Multisig page after toggling from co-signer to not co-signer via upper menu.
- Fixed setting form URL update state.
- Fixed mnemonic issues.
- Fixed UI bugs.