### PR TITLE
Fix QR code container height

### DIFF
--- a/src/components/QRCode/QRCodeDisplay/QRCodeDisplay.less
+++ b/src/components/QRCode/QRCodeDisplay/QRCodeDisplay.less
@@ -18,7 +18,6 @@
     padding: 0.05rem 0.1rem;
     text-align: center;
     width: 2.1rem;
-    height: 2.4rem;
     img {
         width: 1.9rem;
     }


### PR DESCRIPTION
This removes the fixed height of `qrcode-display` css class as sometimes it is too small.

Example:

![image](https://user-images.githubusercontent.com/77545287/104818699-6ff28400-5829-11eb-9790-28a4ffe81d68.png)
