### PR TITLE
Enable scrolling on mosaic/namespace creation pages

### DIFF
--- a/src/views/pages/assets/AssetFormPageWrap/AssetFormPageWrap.less
+++ b/src/views/pages/assets/AssetFormPageWrap/AssetFormPageWrap.less
@@ -1,6 +1,5 @@
 @import '../../../resources/css/variables.less';
 .asset-form-main-container {
-    overflow: hidden;
     position: relative;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
This enables scrollbars on mosaic, namespace and sub-namespace creation pages if necessary.