### PR TITLE
Fix asset filter list scrolling

### DIFF
--- a/src/components/MosaicBalanceList/MosaicBalanceList.less
+++ b/src/components/MosaicBalanceList/MosaicBalanceList.less
@@ -55,7 +55,6 @@
 }
 
 .mosaicList {
-    height: 100%;
     display: block;
 
     .complete_container {
@@ -109,7 +108,6 @@
 }
 
 .searchMosaic {
-    height: 100%;
     .mosaic_data {
         .mosaic_name {
             left: 0.7rem;
@@ -240,12 +238,6 @@
     }
 }
 
-.mosaic-data-list {
-    .mosaic_data:last-child {
-        margin-bottom: 0.53rem;
-    }
-}
-
 .padding_top_0 {
     padding-top: 0 !important;
     height: 0.55rem !important;
@@ -287,16 +279,13 @@
 }
 
 .mosaics-list-container {
-    height: 100%;
+    overflow: auto;
     /deep/.ivu-tabs {
         height: 100%;
         .ivu-tabs-content {
             height: calc(100% - 0.45rem);
             overflow-y: auto;
         }
-    }
-    .searchMosaic {
-        overflow-y: auto;
     }
 }
 


### PR DESCRIPTION
This removes an unnecessary scrollbar in asset filter list:

![image](https://user-images.githubusercontent.com/77545287/104819797-28bbc180-5830-11eb-8296-611c5e408354.png)
