### PR TITLE
Fix connectivity indicator color

### DIFF
--- a/src/components/PeerSelector/PeerSelector.less
+++ b/src/components/PeerSelector/PeerSelector.less
@@ -76,7 +76,6 @@
         display: inline-block;
         width: 14px;
         height: 14px;
-        background-color: #18b566;
         border-radius: 50%;
     }
 
@@ -93,8 +92,14 @@
     }
 }
 
+.endpoint-healthy {
+    i.point {
+        background-color: #18b566;
+    }
+}
+
 .endpoint-unhealthy {
-    i {
+    i.point {
         background-color: red;
     }
 }


### PR DESCRIPTION
The connectivity indicator was always green, even when there was no connection to any node.