### PR TITLE
Export transactions modal dialog layout improvements

### DIFF
--- a/src/views/modals/ModalTransactionExport/ModalTransactionExport.less
+++ b/src/views/modals/ModalTransactionExport/ModalTransactionExport.less
@@ -16,11 +16,6 @@
 @import '../../resources/css/variables.less';
 
 .body {
-    width: 100%;
-    display: grid;
-    grid-template-rows: 1.4rem 2rem 1rem;
-    grid-template-columns: 100%;
-
     .explain {
         padding: 0.2rem;
         padding-left: 0.4rem;
@@ -42,13 +37,17 @@
         height: 2rem;
         margin: auto;
     }
+}
 
-    .download-button {
-        margin: auto;
-        padding: 0.1rem 0.2rem;
-        border-radius: 0.04rem;
-        span {
-            vertical-align: text-bottom;
-        }
+.download-button {
+    padding: 0.05rem 0.2rem;
+    display: flex;
+    align-items: center;
+    span {
+        margin-left: 0.05rem;
     }
+}
+
+.modal-footer {
+    margin: auto;
 }

--- a/src/views/modals/ModalTransactionExport/ModalTransactionExport.vue
+++ b/src/views/modals/ModalTransactionExport/ModalTransactionExport.vue
@@ -9,15 +9,17 @@
                     <span class="subtitle">{{ $t('accounts_backup_transactions') }}</span>
                     <p>{{ $t('accounts_backup_transactions_description') }}</p>
                 </div>
-                <button class="button-style validation-button download-button" type="button" @click="onDownloadTx">
+            </div>
+            <div slot="footer" class="modal-footer">
+                <button
+                    v-if="hasTransactionExportInfo"
+                    class="button-style inverted-button download-button"
+                    type="button"
+                    @click="onDownloadTx"
+                >
                     <Icon :type="'md-download'" size="20" />
                     <span>&nbsp;{{ $t('button_download_qr') }}</span>
                 </button>
-            </div>
-            <div slot="footer" class="modal-footer">
-                <!--<button type="submit" class="centered-button button-style back-button float-right" @click="show = false">
-                    {{ $t('close') }}
-                </button>-->
             </div>
         </Modal>
     </div>


### PR DESCRIPTION
This addresses #919. Removed unnecessary whitespace, moved the download button to the footer and fixed the alignment.

![grafik](https://user-images.githubusercontent.com/77545287/104847547-f7e79500-58e0-11eb-8269-ca02887b48ba.png)
