### PR TITLE
Several address handling fixes

### DIFF
--- a/src/components/AccountAddressDisplay/AccountAddressDisplay.vue
+++ b/src/components/AccountAddressDisplay/AccountAddressDisplay.vue
@@ -1,10 +1,8 @@
 <template>
     <div class="account-detail-row-3cols">
         <span class="label">{{ $t('account_address') }}:</span>
-        <div class="value accountAddress">
-            {{ getPrettyAddress() }}
-        </div>
-        <ButtonCopyToClipboard v-model="address">
+        <div class="value accountAddress">{{ prettyAddress }}</div>
+        <ButtonCopyToClipboard v-model="prettyAddress">
             <img src="@/views/resources/img/account/cloneIcon.svg" class="copy-icon" />
         </ButtonCopyToClipboard>
     </div>

--- a/src/components/AccountAddressDisplay/AccountAddressDisplay.vue
+++ b/src/components/AccountAddressDisplay/AccountAddressDisplay.vue
@@ -2,7 +2,7 @@
     <div class="account-detail-row-3cols">
         <span class="label">{{ $t('account_address') }}:</span>
         <div class="value accountAddress">{{ prettyAddress }}</div>
-        <ButtonCopyToClipboard v-model="prettyAddress">
+        <ButtonCopyToClipboard v-model="address">
             <img src="@/views/resources/img/account/cloneIcon.svg" class="copy-icon" />
         </ButtonCopyToClipboard>
     </div>

--- a/src/components/AccountAddressDisplay/AccountAddressDisplayTs.ts
+++ b/src/components/AccountAddressDisplay/AccountAddressDisplayTs.ts
@@ -30,7 +30,7 @@ export class AccountAddressDisplayTs extends Vue {
     })
     address: string;
 
-    public getPrettyAddress(): string {
+    public get prettyAddress(): string {
         return this.address ? Address.createFromRawAddress(this.address).pretty() : '';
     }
 

--- a/src/components/AccountPublicKeyDisplay/AccountPublicKeyDisplay.vue
+++ b/src/components/AccountPublicKeyDisplay/AccountPublicKeyDisplay.vue
@@ -1,9 +1,7 @@
 <template>
     <div class="account-detail-row-3cols">
         <span v-if="!publicKey" class="label">{{ $t('account_public_key') }}:</span>
-        <div class="value accountPublicKey">
-            {{ publicKey || account.publicKey }}
-        </div>
+        <div class="value accountPublicKey">{{ publicKey || account.publicKey }}</div>
         <ButtonCopyToClipboard v-if="account" v-model="account.publicKey">
             <img src="@/views/resources/img/account/cloneIcon.svg" class="copy-icon" />
         </ButtonCopyToClipboard>

--- a/src/components/ContactDetailPanel/ContactDetailPanel.vue
+++ b/src/components/ContactDetailPanel/ContactDetailPanel.vue
@@ -19,8 +19,8 @@
                     <div class="detail-row">
                         <FormInputEditable
                             :model="selectedContact"
-                            :value="selectedContact.address"
-                            :new-value="selectedContact.address"
+                            :value="address"
+                            :new-value="address"
                             :editing="false"
                             :rules="validationRules.addressOrPublicKey"
                             :label="$t('contact_address')"

--- a/src/components/ContactDetailPanel/ContactDetailPanelTs.ts
+++ b/src/components/ContactDetailPanel/ContactDetailPanelTs.ts
@@ -47,9 +47,9 @@ import { Address } from 'symbol-sdk';
             addressBook: 'addressBook/getAddressBook',
             selectedContact: 'addressBook/getSelectedContact',
         }),
-        address: function() {
+        address: function () {
             return Address.createFromRawAddress(this.selectedContact.address).pretty();
-        }
+        },
     },
 })
 export class ContactDetailPanelTs extends Vue {

--- a/src/components/ContactDetailPanel/ContactDetailPanelTs.ts
+++ b/src/components/ContactDetailPanel/ContactDetailPanelTs.ts
@@ -31,6 +31,7 @@ import FormInputEditable from '@/components/FormInputEditable/FormInputEditable.
 import ModalConfirm from '@/views/modals/ModalConfirm/ModalConfirm.vue';
 import { AddressBook, IContact } from 'symbol-address-book';
 import { ValidationRuleset } from '@/core/validation/ValidationRuleset';
+import { Address } from 'symbol-sdk';
 
 @Component({
     components: {
@@ -46,6 +47,9 @@ import { ValidationRuleset } from '@/core/validation/ValidationRuleset';
             addressBook: 'addressBook/getAddressBook',
             selectedContact: 'addressBook/getSelectedContact',
         }),
+        address: function() {
+            return Address.createFromRawAddress(this.selectedContact.address).pretty();
+        }
     },
 })
 export class ContactDetailPanelTs extends Vue {
@@ -62,7 +66,13 @@ export class ContactDetailPanelTs extends Vue {
 
     public saveProperty(propName: string) {
         return (newVal: string) => {
-            this.selectedContact[propName] = newVal;
+            if (propName === 'address') {
+                const plainAddress = Address.createFromRawAddress(this.selectedContact.address).plain();
+                this.selectedContact[propName] = plainAddress;
+                this.$forceUpdate();
+            } else {
+                this.selectedContact[propName] = newVal;
+            }
             this.$store.dispatch('addressBook/UPDATE_CONTACT', { id: this.selectedContact.id, contact: this.selectedContact });
         };
     }

--- a/src/components/TransactionDetails/TransactionDetailRow/TransactionDetailRow.vue
+++ b/src/components/TransactionDetails/TransactionDetailRow/TransactionDetailRow.vue
@@ -30,9 +30,7 @@
                     :signer="item.value.signer"
                 />
             </span>
-            <span v-else>
-                {{ item.value }}
-            </span>
+            <span v-else>{{ item.value }}</span>
         </div>
     </div>
 </template>

--- a/src/views/forms/FormContactCreation/FormContactCreationTs.ts
+++ b/src/views/forms/FormContactCreation/FormContactCreationTs.ts
@@ -31,6 +31,7 @@ import ModalFormProfileUnlock from '@/views/modals/ModalFormProfileUnlock/ModalF
 import { ProfileModel } from '@/core/database/entities/ProfileModel';
 import { FilterHelpers } from '@/core/utils/FilterHelpers';
 import { AddressBook } from 'symbol-address-book/AddressBook';
+import { Address } from 'symbol-sdk';
 
 @Component({
     components: {
@@ -88,8 +89,9 @@ export class FormContactCreationTs extends Vue {
      * @return {void}
      */
     public onSubmit() {
+        const address = Address.createFromRawAddress(this.formItems.address);
         const contacts = this.addressBook.getAllContacts();
-        const isSameAddress = contacts.some((contact) => contact.address === this.formItems.address);
+        const isSameAddress = contacts.some((contact) => contact.address === address.plain());
 
         if (isSameAddress) {
             this.$store.dispatch('notification/ADD_ERROR', this.$t('error_contact_already_exists'));
@@ -99,7 +101,7 @@ export class FormContactCreationTs extends Vue {
 
         this.$store.dispatch('addressBook/ADD_CONTACT', {
             name: this.formItems.name,
-            address: this.formItems.address,
+            address: address.plain(),
         });
         this.$emit('submit');
     }


### PR DESCRIPTION
- Now copying pretty account address to clipboard instead of plain
- Removed spaces before and after the address in account details
- Now saving contact addresses as plain and therefore preventing creation of duplicate contacts
- Always display pretty contact addresses instead of saved one