### PR TITLE
Prevent closing the terms and conditions modal dialog

### DIFF
--- a/src/views/modals/ModalTermsAndConditions/ModalTermsAndConditions.vue
+++ b/src/views/modals/ModalTermsAndConditions/ModalTermsAndConditions.vue
@@ -1,6 +1,13 @@
 <template>
     <div>
-        <Modal v-model="show" class="modal-terms-and-conditions" :title="$t('terms_and_conditions')" :footer-hide="true">
+        <Modal
+            v-model="show"
+            class="modal-terms-and-conditions"
+            :title="$t('terms_and_conditions')"
+            :footer-hide="true"
+            :closable="false"
+            :mask-closable="false"
+        >
             <div class="container">
                 <div class="centered-content bottom-space">
                     <Icon type="ios-alert-outline" size="50" />


### PR DESCRIPTION
The terms and conditions modal dialog could be closed without accepting. This is now prevented.
This partly solves #946. It is still possible to navigate to all pages except Home after clicking on terms of service.