### PR TITLE
Fix importance score display

### DIFF
--- a/src/components/ImportanceScoreDisplay/ImportanceScoreDisplayTs.ts
+++ b/src/components/ImportanceScoreDisplay/ImportanceScoreDisplayTs.ts
@@ -45,6 +45,11 @@ export class ImportanceScoreDisplayTs extends Vue {
         if (!accountInfo) {
             return '0';
         }
+
+        if (!this.networkCurrency?.divisibility || !this.networkConfiguration?.totalChainImportance) {
+            return 'N/A';
+        }
+
         const importance = accountInfo.importance.compact();
 
         const relativeImportance = importance > 0 ? importance / this.networkConfiguration.totalChainImportance : importance;

--- a/src/components/ImportanceScoreDisplay/ImportanceScoreDisplayTs.ts
+++ b/src/components/ImportanceScoreDisplay/ImportanceScoreDisplayTs.ts
@@ -47,17 +47,15 @@ export class ImportanceScoreDisplayTs extends Vue {
         }
         const importance = accountInfo.importance.compact();
 
-        const relativeImportance = importance > 0
-            ? importance / this.networkConfiguration.totalChainImportance
-            : importance;
+        const relativeImportance = importance > 0 ? importance / this.networkConfiguration.totalChainImportance : importance;
 
         const divisibility = this.networkCurrency.divisibility;
         const formatOptions: Intl.NumberFormatOptions = {
             maximumFractionDigits: divisibility,
             minimumFractionDigits: divisibility,
-            style: 'percent'
+            style: 'percent',
         };
-        return (relativeImportance).toLocaleString(undefined, formatOptions);
+        return relativeImportance.toLocaleString(undefined, formatOptions);
     }
 
     /// end-region computed properties getter/setter

--- a/src/components/ImportanceScoreDisplay/ImportanceScoreDisplayTs.ts
+++ b/src/components/ImportanceScoreDisplay/ImportanceScoreDisplayTs.ts
@@ -17,11 +17,15 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 import { AccountInfo } from 'symbol-sdk';
 // internal dependencies
 import { mapGetters } from 'vuex';
+import { NetworkCurrencyModel } from '@/core/database/entities/NetworkCurrencyModel';
+import { NetworkConfigurationModel } from '@/core/database/entities/NetworkConfigurationModel';
 
 @Component({
     computed: {
         ...mapGetters({
             accountsInfo: 'account/accountsInfo',
+            networkCurrency: 'mosaic/networkCurrency',
+            networkConfiguration: 'network/networkConfiguration',
         }),
     },
 })
@@ -31,10 +35,9 @@ export class ImportanceScoreDisplayTs extends Vue {
     })
     address: string;
 
-    /**
-     *
-     */
     private accountsInfo: AccountInfo[];
+    private networkCurrency: NetworkCurrencyModel;
+    private networkConfiguration: NetworkConfigurationModel;
 
     /// region computed properties getter/setter
     get score(): string {
@@ -43,7 +46,18 @@ export class ImportanceScoreDisplayTs extends Vue {
             return '0';
         }
         const importance = accountInfo.importance.compact();
-        return importance.toString();
+
+        const relativeImportance = importance > 0
+            ? importance / this.networkConfiguration.totalChainImportance
+            : importance;
+
+        const divisibility = this.networkCurrency.divisibility;
+        const formatOptions: Intl.NumberFormatOptions = {
+            maximumFractionDigits: divisibility,
+            minimumFractionDigits: divisibility,
+            style: 'percent'
+        };
+        return (relativeImportance).toLocaleString(undefined, formatOptions);
     }
 
     /// end-region computed properties getter/setter

--- a/src/config/NetworkConfig.ts
+++ b/src/config/NetworkConfig.ts
@@ -38,6 +38,7 @@ export interface NetworkConfigurationDefaults {
     maxMosaicDivisibility: number;
     maxMessageSize: number;
     epochAdjustment: number;
+    totalChainImportance: number;
 }
 
 export interface NetworkConfig {
@@ -72,6 +73,7 @@ const defaultNetworkConfig: NetworkConfig = {
         harvestingMosaicId: '5F160D7851F3CB30',
         defaultDynamicFeeMultiplier: 1000,
         epochAdjustment: 1573430400,
+        totalChainImportance: 1,
     },
     nodes: [
         { friendlyName: 'API North East 1', roles: 2, url: 'http://api-01.ap-northeast-1.testnet.symboldev.network:3000' },

--- a/src/config/NetworkConfig.ts
+++ b/src/config/NetworkConfig.ts
@@ -73,7 +73,7 @@ const defaultNetworkConfig: NetworkConfig = {
         harvestingMosaicId: '5F160D7851F3CB30',
         defaultDynamicFeeMultiplier: 1000,
         epochAdjustment: 1573430400,
-        totalChainImportance: 1,
+        totalChainImportance: undefined,
     },
     nodes: [
         { friendlyName: 'API North East 1', roles: 2, url: 'http://api-01.ap-northeast-1.testnet.symboldev.network:3000' },

--- a/src/core/database/entities/NetworkConfigurationModel.ts
+++ b/src/core/database/entities/NetworkConfigurationModel.ts
@@ -32,4 +32,5 @@ export class NetworkConfigurationModel {
     public readonly currencyMosaicId: string;
     public readonly harvestingMosaicId: string;
     public readonly defaultDynamicFeeMultiplier: number;
+    public readonly totalChainImportance: number;
 }

--- a/src/core/utils/NetworkConfigurationHelpers.ts
+++ b/src/core/utils/NetworkConfigurationHelpers.ts
@@ -276,8 +276,7 @@ export class NetworkConfigurationHelpers {
         defaultValue: number | undefined = undefined,
     ): number {
         return (
-            (networkConfiguration?.chain &&
-                Formatters.configurationNumberAsNumber(networkConfiguration.chain.totalChainImportance)) ||
+            (networkConfiguration?.chain && Formatters.configurationNumberAsNumber(networkConfiguration.chain.totalChainImportance)) ||
             defaultValue ||
             this.defaults.totalChainImportance
         );

--- a/src/core/utils/NetworkConfigurationHelpers.ts
+++ b/src/core/utils/NetworkConfigurationHelpers.ts
@@ -270,4 +270,16 @@ export class NetworkConfigurationHelpers {
             this.defaults.defaultDynamicFeeMultiplier
         );
     }
+
+    public static totalChainImportance(
+        networkConfiguration: NetworkConfiguration | undefined,
+        defaultValue: number | undefined = undefined,
+    ): number {
+        return (
+            (networkConfiguration?.chain &&
+                Formatters.configurationNumberAsNumber(networkConfiguration.chain.totalChainImportance)) ||
+            defaultValue ||
+            this.defaults.totalChainImportance
+        );
+    }
 }

--- a/src/services/NetworkService.ts
+++ b/src/services/NetworkService.ts
@@ -174,6 +174,7 @@ export class NetworkService {
             currencyMosaicId: NetworkConfigurationHelpers.currencyMosaicId(dto),
             harvestingMosaicId: NetworkConfigurationHelpers.harvestingMosaicId(dto),
             defaultDynamicFeeMultiplier: NetworkConfigurationHelpers.defaultDynamicFeeMultiplier(dto),
+            totalChainImportance: NetworkConfigurationHelpers.totalChainImportance(dto),
         };
         return { ...fileDefaults, ...fromDto };
     }


### PR DESCRIPTION
This fixes the importance score display (issue #670).

Therefore the totalChainImportance had to be added to the NetworkConfigurationModel with a default value. I created this pull request as a draft because I have no idea what default value should be used here. Actually I don't know why default values are used at all as it would lead to displaying wrong values. I set it to 1 which is maybe not what you want.