### PR TITLE
Changed create profile submit button text, harmonized button sizes

### DIFF
--- a/src/views/forms/FormProfileCreation/FormProfileCreation.vue
+++ b/src/views/forms/FormProfileCreation/FormProfileCreation.vue
@@ -127,7 +127,7 @@
                             {{ $t('back') }}
                         </button>
                         <button type="submit" class="inverted-button button-style create-account-style" @click="handleSubmit(submit)">
-                            {{ $t(nextPage === 'profiles.importProfile.importMnemonic' ? 'restore_mnemonic' : 'generating_mnemonic') }}
+                            {{ $t('next') }}
                         </button>
                     </div>
                 </form>
@@ -171,6 +171,10 @@ export default class FormProfileCreation extends FormProfileCreationTs {}
 
 .form-wrapper {
     width: 100%;
+}
+
+.create-account-style {
+    width: 150px;
 }
 
 /deep/ .form-row {


### PR DESCRIPTION
The submit button text of the create profile page was not displayed completely because it was too long. I changed it to 'Next' as in the following dialogs. I think the page title is sufficient to know what will happen...