### PR TITLE
Use document's mouseover event for entropy generation

### DIFF
--- a/src/views/pages/profiles/create-profile/generate-mnemonic/GenerateMnemonic.vue
+++ b/src/views/pages/profiles/create-profile/generate-mnemonic/GenerateMnemonic.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="step-2-wrapper" @mouseover="shouldTrackMouse && handleMousemove($event)">
+    <div class="step-2-wrapper">
         <img src="@/views/resources/img/login/connector-pink.png" />
         <Progress stroke-color="#ff00ff" :percent="percent" />
     </div>

--- a/src/views/pages/profiles/create-profile/generate-mnemonic/GenerateMnemonicTs.ts
+++ b/src/views/pages/profiles/create-profile/generate-mnemonic/GenerateMnemonicTs.ts
@@ -71,6 +71,22 @@ export default class GenerateMnemonicTs extends Vue {
     private percent: number = 0;
 
     /**
+     * Hook called when the layout is mounted
+     * @return {void}
+     */
+    public mounted(): void {
+        document.addEventListener('mouseover', this.handleMousemove);
+    }
+
+    /**
+     * Hook called when the component is destroyed
+     * @return {void}
+     */
+    public destroyed(): void {
+        document.removeEventListener('mouseover', this.handleMousemove);
+    }
+
+    /**
      * Track and handle mouse move event
      * @param {Vue.Event} event
      * @return {void}


### PR DESCRIPTION
When "generating a mnemonic" currently the mouseover event of the GenerateMnemonic component is used. Now using the document's mouseover event for more convenience and maybe even more randomness.