### PR TITLE
Transaction confirmation modal dialog layout improvements/fixes

### DIFF
--- a/src/components/TransactionDetails/TransactionDetails.less
+++ b/src/components/TransactionDetails/TransactionDetails.less
@@ -27,8 +27,6 @@
 }
 
 .transaction-details-item-inner-container {
-    display: grid;
-    grid-row-gap: 0.03rem;
     margin-bottom: 0.2rem;
 }
 
@@ -61,7 +59,6 @@
         font-family: @symbolFontLight;
         overflow: hidden;
         word-break: break-word;
-        display: grid;
         align-items: center;
     }
 }

--- a/src/views/modals/ModalTransactionConfirmation/ModalTransactionConfirmation.vue
+++ b/src/views/modals/ModalTransactionConfirmation/ModalTransactionConfirmation.vue
@@ -5,7 +5,6 @@
             class-name="modal-transaction-confirmation"
             :title="$t('modal_title_transaction_confirmation')"
             :transfer="false"
-            :footer-hide="true"
         >
             <div class="transactionConfirmationBody">
                 <div v-if="!!stagedTransactions" class="stepItem1">
@@ -14,10 +13,11 @@
                             <TransactionDetails :transaction="transaction" />
                         </div>
                     </div>
-
-                    <HardwareConfirmationButton v-if="isUsingHardwareWallet" @success="onSigner" @error="onError" />
-                    <FormProfileUnlock v-else @success="onAccountUnlocked" @error="onError" />
                 </div>
+            </div>
+            <div class="footer" slot="footer">
+                <HardwareConfirmationButton v-if="isUsingHardwareWallet" @success="onSigner" @error="onError" />
+                <FormProfileUnlock v-else @success="onAccountUnlocked" @error="onError" />
             </div>
         </Modal>
     </div>
@@ -31,11 +31,6 @@ export default class ModalTransactionConfirmation extends ModalTransactionConfir
 <style lang="less" scoped>
 @import '../../resources/css/variables.less';
 
-.info_container {
-    height: 5rem;
-    overflow-y: auto;
-}
-
 .float-right {
     float: right;
 }
@@ -43,5 +38,14 @@ export default class ModalTransactionConfirmation extends ModalTransactionConfir
 .clear-staged-transactions {
     font-size: @smallFont;
     cursor: pointer;
+}
+
+.footer {
+    width: 100%;
+}
+
+/deep/ .ivu-modal-footer {
+    height: unset;
+    padding-top: 0;
 }
 </style>


### PR DESCRIPTION
Moved the password input and confirmation button to modal footer so it is visible even if content has a scrollbar. Also removed useless whitespace and fixed spacing in transaction details.

Before:
![grafik](https://user-images.githubusercontent.com/77545287/106057283-0e1aff80-60f0-11eb-81a6-0cabeff0fb2a.png)

Now:
![grafik](https://user-images.githubusercontent.com/77545287/106057310-18d59480-60f0-11eb-9f21-0ba751a1c64c.png)
