### PR TITLE
Mask password characters in confirmation input box

### DIFF
--- a/src/views/forms/FormProfilePasswordUpdate/FormProfilePasswordUpdate.vue
+++ b/src/views/forms/FormProfilePasswordUpdate/FormProfilePasswordUpdate.vue
@@ -46,6 +46,7 @@
                                     v-model="formItems.passwordConfirm"
                                     class="input-size input-style"
                                     :placeholder="$t('form_label_new_password_confirm')"
+                                    type="password"
                                     @input="onChange"
                                 />
                             </ErrorTooltip>


### PR DESCRIPTION
The password confirmation input box in the settings currently is a normal text input.