### PR TITLE
Close settings modal dialog on confirm

### DIFF
--- a/src/views/forms/FormGeneralSettings/FormGeneralSettingsTs.ts
+++ b/src/views/forms/FormGeneralSettings/FormGeneralSettingsTs.ts
@@ -142,6 +142,7 @@ export class FormGeneralSettingsTs extends Vue {
             // - add notification and emit
             this.$store.dispatch('notification/ADD_SUCCESS', NotificationType.SUCCESS_SETTINGS_UPDATED);
             this.$emit('submit', this.formItems);
+            this.$emit('close');
         } catch (e) {
             this.$store.dispatch('notification/ADD_ERROR', 'An error happened, please try again.');
             console.error(e);

--- a/src/views/modals/ModalSettings/ModalSettings.vue
+++ b/src/views/modals/ModalSettings/ModalSettings.vue
@@ -16,7 +16,7 @@
             </div>
 
             <div v-if="knownTabs[currentTabIndex] === 'GENERAL' && !!currentAccount">
-                <FormGeneralSettings @logout="logout" />
+                <FormGeneralSettings @logout="logout" @close="close" />
             </div>
 
             <div v-if="knownTabs[currentTabIndex] === 'PASSWORD' && !!currentAccount">

--- a/src/views/modals/ModalSettings/ModalSettingsTs.ts
+++ b/src/views/modals/ModalSettings/ModalSettingsTs.ts
@@ -99,4 +99,8 @@ export class ModalSettingsTs extends Vue {
         this.$emit('close');
         this.$router.push({ name: 'profiles.login' });
     }
+
+    public close() {
+        this.$emit('close');
+    }
 }


### PR DESCRIPTION
When confirming general settings, the dialog now closes after entering the (correct) password.