### PR TITLE
Settings: fixed node url auto completion and renamed button

### DIFF
--- a/src/language/en-US.json
+++ b/src/language/en-US.json
@@ -94,6 +94,7 @@
     "add_metadata": "Add metadata",
     "add_mosaic": "Add a mosaic",
     "add_mosaic_restrictions": "New mosaic restriction",
+    "add_node": "Add node",
     "add_operation_restrictions": "New operation restriction",
     "address": "Address",
     "address_alias_not_exist": "Address alias does not exist",

--- a/src/language/ja-JP.json
+++ b/src/language/ja-JP.json
@@ -94,6 +94,7 @@
     "add_metadata": "メタデータ追加",
     "add_mosaic": "モザイク追加",
     "add_mosaic_restrictions": "新規モザイク制限",
+    "add_node": "ノードを追加",
     "add_operation_restrictions": "新規操作制限",
     "address": "アドレス",
     "address_alias_not_exist": "アドレスエイリアスは存在しません",

--- a/src/language/zh-CN.json
+++ b/src/language/zh-CN.json
@@ -94,6 +94,7 @@
     "add_metadata": "添加元数据",
     "add_mosaic": "添加马赛克",
     "add_mosaic_restrictions": "新的镶嵌限制",
+    "add_node": "添加节点",
     "add_operation_restrictions": "新操作限制",
     "address": "地址",
     "address_alias_not_exist": "地址别名不存在",

--- a/src/views/forms/FormNodeEdit/FormNodeEdit.vue
+++ b/src/views/forms/FormNodeEdit/FormNodeEdit.vue
@@ -63,7 +63,7 @@
                     :disabled="!formItems.networkHash"
                     @click="handleSubmit(onSubmit)"
                 >
-                    {{ $t('confirm') }}
+                    {{ $t('add_node') }}
                 </button>
             </div>
         </ValidationObserver>

--- a/src/views/forms/FormNodeEdit/FormNodeEditTs.ts
+++ b/src/views/forms/FormNodeEdit/FormNodeEditTs.ts
@@ -82,7 +82,7 @@ export class FormNodeEditTs extends Vue {
             this.$store.dispatch('notification/ADD_ERROR', this.$t(NotificationType.ERROR_PEER_UNREACHABLE));
         }
     }
-    public async getInfoFromUrl() {
+    public async getInfoFromUrl(url: string) {
         if (this.$refs.observer.fields && this.$refs.observer.fields.nodeUrl.invalid) {
             this.formItems.networkHash = '';
             this.formItems.networkType = '';
@@ -91,7 +91,7 @@ export class FormNodeEditTs extends Vue {
         const networkService = new NetworkService();
         this.isGettingNodeInfo = true;
         try {
-            const { networkModel, isCandidateUrlAvailable } = await networkService.getNetworkModel(this.formItems.nodeUrl).toPromise();
+            const { networkModel, isCandidateUrlAvailable } = await networkService.getNetworkModel(url).toPromise();
             if (!isCandidateUrlAvailable) {
                 return this.$store.dispatch('notification/ADD_WARNING', this.$t(NotificationType.INVALID_NODE));
             }
@@ -113,7 +113,8 @@ export class FormNodeEditTs extends Vue {
             this.customNodeData = [];
             return;
         }
-        const associationValues: Array<string> = /.+\u003a\d{2,}/.test(value) ? [value] : [value + ':3000'];
-        this.customNodeData = !value ? [] : associationValues;
+        let associationValue: string = /.+\u003a\d{2,}/.test(value) ? value : value + ':3000';
+        associationValue = /https?\:\/\/.+/.test(associationValue) ? associationValue : 'http://' + associationValue;
+        this.customNodeData = !value ? [] : [associationValue];
     }
 }


### PR DESCRIPTION
When selecting an auto completion suggestion in the node URL input field, previously not the suggestion was used for testing the node but the text entered in the input field. Now the suggestion is used.

Also 'http://' is added if not present (doesn't work without it).

Additionally I renamed the confirm button to 'Add node' (Chinese and Japanese translations are already reviewed).