### PR TITLE
Fix simple aggregate transaction address validation

### DIFF
--- a/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
+++ b/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
@@ -514,7 +514,7 @@ export class FormTransferTransactionTs extends FormTransactionBase {
     }
 
     triggerChange() {
-        if (Address.isValidRawAddress(this.formItems.recipientRaw)) {
+        if (AddressValidator.validate(this.formItems.recipientRaw)) {
             this.transactions = this.getTransactions();
             // avoid error
             if (this.transactions) {


### PR DESCRIPTION
This fixes validation of simple aggregate transaction's recipient address so that pretty addresses are now also accepted.