### PR TITLE
Disable inputs and create profile link during login

### DIFF
--- a/src/views/pages/profiles/LoginPage.less
+++ b/src/views/pages/profiles/LoginPage.less
@@ -352,3 +352,7 @@
         font-size: @smallerFont;
     }
 }
+
+.disabled {
+    cursor: default !important;
+}

--- a/src/views/pages/profiles/LoginPage.vue
+++ b/src/views/pages/profiles/LoginPage.vue
@@ -29,6 +29,7 @@
                                         v-model="formItems.currentProfileName"
                                         placeholder=" "
                                         :class="['select-account', !profilesClassifiedByNetworkType ? 'un_click' : 'profile-name-input']"
+                                        :disabled="performingLogin"
                                     >
                                         <div class="auto-complete-sub-container scroll">
                                             <div class="tips-in-sub-container">
@@ -72,7 +73,7 @@
                                         :class="[!profilesClassifiedByNetworkType ? 'un_click' : '']"
                                         :placeholder="$t('please_enter_your_account_password')"
                                         type="password"
-                                        :disabled="!profilesClassifiedByNetworkType"
+                                        :disabled="!profilesClassifiedByNetworkType || performingLogin"
                                     />
                                 </ErrorTooltip>
                             </ValidationProvider>
@@ -83,10 +84,13 @@
                                 }}</span>
                                 <span
                                     class="pointer create-profile"
+                                    v-bind:class="{ disabled: performingLogin }"
                                     @click="
-                                        $router.push({
-                                            name: 'profiles.importProfile.importStrategy',
-                                        })
+                                        if (!performingLogin) {
+                                            $router.push({
+                                                name: 'profiles.importProfile.importStrategy',
+                                            });
+                                        }
                                     "
                                 >
                                     {{ $t('create_a_new_account') }}?


### PR DESCRIPTION
When clicking on create profile while logging in, the create profile page is shown but as soon as the login is complete, you get redirected to the wallet. So I disable it during login process.

I noticed this seemingly useless input, can it be deleted?
LoginPage.vue line 26:

    <input v-show="false" v-model="formItems.currentProfileName" />