### PR TITLE
Improved import mnemonic usability

### DIFF
--- a/src/components/MnemonicInput/MnemonicInput.vue
+++ b/src/components/MnemonicInput/MnemonicInput.vue
@@ -11,7 +11,7 @@
                 maxlength="50"
                 @paste.prevent="handlePaste($event)"
                 @keyup.space="addWord"
-                @keyup.delete="deleteWord"
+                @keydown.delete="deleteWord"
             />
         </div>
         <ButtonCopyToClipboard v-model="waitingCopyString" class="copy-button" />


### PR DESCRIPTION
Import profile -> mnemonic words input: Changed the delete key event from keyup to keydown so that now you can just hold down backspace to delete all words. Before you had to repeatedly press backspace to delete the words one by one.