### PR TITLE
Removed unnecessary notifications

### DIFF
--- a/src/views/forms/FormProfileCreation/FormProfileCreationTs.ts
+++ b/src/views/forms/FormProfileCreation/FormProfileCreationTs.ts
@@ -214,8 +214,6 @@ export class FormProfileCreationTs extends Vue {
         this.$store.dispatch('profile/SET_CURRENT_PROFILE', account);
         this.$store.dispatch('temporary/SET_PASSWORD', this.formItems.password);
         if (!this.isLedger) {
-            this.$store.dispatch('notification/ADD_SUCCESS', NotificationType.OPERATION_SUCCESS);
-
             // flush and continue
             this.$router.push({ name: this.nextPage });
         } else {

--- a/src/views/pages/profiles/create-profile/finalize/FinalizeTs.ts
+++ b/src/views/pages/profiles/create-profile/finalize/FinalizeTs.ts
@@ -125,7 +125,6 @@ export default class FinalizeTs extends Vue {
         await this.$store.dispatch('account/SET_CURRENT_ACCOUNT', account);
         await this.$store.dispatch('account/SET_KNOWN_ACCOUNTS', [account.id]);
         await this.$store.dispatch('temporary/RESET_STATE');
-        await this.$store.dispatch('notification/ADD_SUCCESS', NotificationType.OPERATION_SUCCESS);
 
         // flush and continue
         return this.$router.push({ name: 'dashboard' });

--- a/src/views/pages/profiles/create-profile/generate-mnemonic/GenerateMnemonicTs.ts
+++ b/src/views/pages/profiles/create-profile/generate-mnemonic/GenerateMnemonicTs.ts
@@ -121,7 +121,6 @@ export default class GenerateMnemonicTs extends Vue {
             // update state
             await this.$store.dispatch('profile/SET_CURRENT_PROFILE', this.currentProfile);
             this.$store.dispatch('temporary/SET_MNEMONIC', seed);
-            this.$store.dispatch('notification/ADD_SUCCESS', this.$t('generate_entropy_increase_success'));
 
             // redirect
             return this.$router.push({ name: 'profiles.createProfile.showMnemonic' });

--- a/src/views/pages/profiles/import-profile/account-selection/AccountSelectionTs.ts
+++ b/src/views/pages/profiles/import-profile/account-selection/AccountSelectionTs.ts
@@ -179,7 +179,6 @@ export default class AccountSelectionTs extends Vue {
 
             // execute store actions
             this.$store.dispatch('temporary/RESET_STATE');
-            this.$store.dispatch('notification/ADD_SUCCESS', NotificationType.OPERATION_SUCCESS);
             return this.$router.push({ name: 'profiles.importProfile.finalize' });
         } catch (error) {
             return this.$store.dispatch('notification/ADD_ERROR', error);

--- a/src/views/pages/profiles/import-profile/import-mnemonic/ImportMnemonicTs.ts
+++ b/src/views/pages/profiles/import-profile/import-mnemonic/ImportMnemonicTs.ts
@@ -126,7 +126,6 @@ export default class ImportMnemonicTs extends Vue {
             this.profileService.updateSeed(this.currentProfile, encSeed);
 
             // update state
-            this.$store.dispatch('notification/ADD_SUCCESS', this.$t('generate_entropy_increase_success'));
             this.$store.dispatch('temporary/SET_MNEMONIC', mnemonic.plain);
 
             // redirect


### PR DESCRIPTION
There were lots of unnecessary success notifications during profile creation and import. In case of an error a notification makes sense, but not if everything is ok.

![grafik](https://user-images.githubusercontent.com/77545287/107157281-8650b300-6983-11eb-94c9-29c5e97d13e5.png)

![grafik](https://user-images.githubusercontent.com/77545287/107157285-881a7680-6983-11eb-887c-ea771f3884a4.png)
