### PR TITLE
Harmonize block number display

### DIFF
--- a/src/components/TransactionList/TransactionRow/TransactionRowTs.ts
+++ b/src/components/TransactionList/TransactionRow/TransactionRowTs.ts
@@ -166,7 +166,7 @@ export class TransactionRowTs extends Vue {
     public getHeight(): string {
         const transactionStatus = TransactionView.getTransactionStatus(this.transaction);
         if (transactionStatus == TransactionStatus.confirmed) {
-            return this.view.info?.height.compact().toLocaleString();
+            return this.view.info?.height.compact().toString();
         } else {
             return this.$t(`transaction_status_${transactionStatus}`).toString();
         }

--- a/src/core/transactions/TransactionView.ts
+++ b/src/core/transactions/TransactionView.ts
@@ -127,10 +127,7 @@ export abstract class TransactionView<T extends Transaction> {
             this.getFeeDetailItem(),
             {
                 key: 'block_height',
-                value:
-                    this.info && this.info.height && this.info.height.compact()
-                        ? this.info.height.compact().toString()
-                        : undefined,
+                value: this.info && this.info.height && this.info.height.compact() ? this.info.height.compact().toString() : undefined,
             },
             {
                 key: 'deadline',

--- a/src/core/transactions/TransactionView.ts
+++ b/src/core/transactions/TransactionView.ts
@@ -129,7 +129,7 @@ export abstract class TransactionView<T extends Transaction> {
                 key: 'block_height',
                 value:
                     this.info && this.info.height && this.info.height.compact()
-                        ? `${i18n.t('block')} #${this.info.height.compact()}`
+                        ? this.info.height.compact().toString()
                         : undefined,
             },
             {


### PR DESCRIPTION
Display block number in dashboard table and transaction details plain (without thousands separators and without 'Block #' prefix). This fixes #1082.