### PR TITLE
Fix aggregate save button

### DIFF
--- a/src/components/DisabledFormOverlay/DisabledFormOverlay.vue
+++ b/src/components/DisabledFormOverlay/DisabledFormOverlay.vue
@@ -79,7 +79,6 @@ export default class DisabledFormOverlay extends Vue {
             return NotificationType.NO_NETWORK_CURRENCY;
         }
         if (this.disableToMultisig) {
-            this.$emit('disableForm');
             return NotificationType.MULTISIG_ACCOUNTS_NO_TX;
         }
         return '';

--- a/src/components/FormWrapper/FormWrapper.vue
+++ b/src/components/FormWrapper/FormWrapper.vue
@@ -1,6 +1,6 @@
 <template>
     <div ref="form" class="form-wrapper">
-        <DisabledFormOverlay :whitelisted="whitelisted" @disableForm="blockFunctionalTags" />
+        <DisabledFormOverlay :whitelisted="whitelisted" />
         <slot />
     </div>
 </template>
@@ -23,18 +23,5 @@ export default class FormWrapper extends Vue {
     public $refs!: {
         form: HTMLElement;
     };
-
-    /**
-     * Blocks all content of form if restriction overlay appears.
-     */
-    protected blockFunctionalTags(): void {
-        Vue.nextTick(() => {
-            const childNodes = this.$refs.form.getElementsByTagName('*');
-
-            for (const node of childNodes) {
-                (node as any).disabled = true;
-            }
-        });
-    }
 }
 </script>

--- a/src/views/forms/FormMosaicDefinitionTransaction/FormMosaicDefinitionTransaction.vue
+++ b/src/views/forms/FormMosaicDefinitionTransaction/FormMosaicDefinitionTransaction.vue
@@ -35,9 +35,19 @@
                     </template>
                 </FormRow>
                 <RentalFee :rental-type="'mosaic'"></RentalFee>
-                <MaxFeeAndSubmit v-if="!isAggregate" v-model="formItems.maxFee" @button-clicked="handleSubmit(onSubmit)" />
+                <MaxFeeAndSubmit
+                    v-if="!isAggregate"
+                    v-model="formItems.maxFee"
+                    :disable-submit="currentAccount.isMultisig"
+                    @button-clicked="handleSubmit(onSubmit)"
+                />
                 <div v-else-if="!hideSave" class="ml-2" style="text-align: right;">
-                    <button type="submit" class="save-button centered-button button-style inverted-button" @click="emitToAggregate">
+                    <button
+                        type="submit"
+                        class="save-button centered-button button-style inverted-button"
+                        :disabled="currentAccount.isMultisig"
+                        @click="emitToAggregate"
+                    >
                         {{ $t('save') }}
                     </button>
                 </div>

--- a/src/views/forms/FormNamespaceRegistrationTransaction/FormNamespaceRegistrationTransaction.vue
+++ b/src/views/forms/FormNamespaceRegistrationTransaction/FormNamespaceRegistrationTransaction.vue
@@ -61,9 +61,19 @@
                         :rental-type="formItems.registrationType === typeRootNamespace ? 'root-namespace' : 'child-namespace'"
                         :duration="formItems.duration"
                     />
-                    <MaxFeeAndSubmit v-if="!isAggregate" v-model="formItems.maxFee" @button-clicked="handleSubmit(onSubmit)" />
+                    <MaxFeeAndSubmit
+                        v-if="!isAggregate"
+                        v-model="formItems.maxFee"
+                        :disable-submit="currentAccount.isMultisig"
+                        @button-clicked="handleSubmit(onSubmit)"
+                    />
                     <div v-else-if="!hideSave" class="ml-2" style="text-align: right;">
-                        <button type="submit" class="save-button centered-button button-style inverted-button" @click="emitToAggregate">
+                        <button
+                            type="submit"
+                            class="save-button centered-button button-style inverted-button"
+                            :disabled="currentAccount.isMultisig"
+                            @click="emitToAggregate"
+                        >
                             {{ $t('save') }}
                         </button>
                     </div>

--- a/src/views/forms/FormTransferTransaction/FormTransferTransaction.vue
+++ b/src/views/forms/FormTransferTransaction/FormTransferTransaction.vue
@@ -75,7 +75,12 @@
                         @input="onChangeMaxFee"
                     />
                     <div v-else-if="!hideSave" class="ml-2" style="text-align: right;">
-                        <button type="submit" class="save-button centered-button button-style inverted-button" @click="emitToAggregate">
+                        <button
+                            type="submit"
+                            class="save-button centered-button button-style inverted-button"
+                            :disabled="currentAccount.isMultisig"
+                            @click="emitToAggregate"
+                        >
                             {{ $t('save') }}
                         </button>
                     </div>


### PR DESCRIPTION
When on aggregate page with multisig account, the save button is disabled. When switching to a non-multisig account, it stays disabled. This is because FormWrapper disables all elements in `blockFunctionalTags()` but it never enables them again.

As a solution I removed `blockFunctionalTags()` because there is an overlay blocking input anyway. Also now disabling save and send buttons when current account is multisig.