### PR TITLE
Login page: validate password on submit

### DIFF
--- a/src/views/pages/profiles/LoginPage.vue
+++ b/src/views/pages/profiles/LoginPage.vue
@@ -66,7 +66,7 @@
                             </p>
                             <ValidationProvider
                                 v-slot="{ errors }"
-                                mode="lazy"
+                                mode="passive"
                                 vid="password"
                                 :name="$t('password')"
                                 rules="required|min:8"


### PR DESCRIPTION
Currently when trying to select a profile before entering a password, the password error tooltip is shown on top of the profile selection: https://share.getcloudapp.com/2NuEzO8N

Now validating the password on submit to prevent this.