### PR TITLE
Do not reset transfer tx form on signer change

### DIFF
--- a/src/components/MosaicSelector/MosaicSelector.vue
+++ b/src/components/MosaicSelector/MosaicSelector.vue
@@ -1,5 +1,5 @@
 <template>
-    <ValidationProvider v-slot="{ errors }" vid="selectedMosaic" :name="$t(label)" :rules="'required'" tag="div" class="select-container">
+    <ValidationProvider v-slot="{ errors }" vid="selectedMosaic" :name="$t(label)" rules="required" tag="div" class="select-container">
         <ErrorTooltip :errors="errors">
             <Select v-model="selectedMosaic" v-focus :disabled="disabled" class="select-size select-style">
                 <Option v-for="m in displayedMosaics" :key="m.mosaicIdHex" :value="m.mosaicIdHex">

--- a/src/components/MosaicSelector/MosaicSelectorTs.ts
+++ b/src/components/MosaicSelector/MosaicSelectorTs.ts
@@ -54,7 +54,7 @@ export class MosaicSelectorTs extends Vue {
     /**
      * Field label hidden by default
      */
-    @Prop({ default: null }) label: string;
+    @Prop({ default: 'mosaic' }) label: string;
 
     /**
      * Disable mosaic selector

--- a/src/views/forms/FormAliasTransaction/FormAliasTransaction.vue
+++ b/src/views/forms/FormAliasTransaction/FormAliasTransaction.vue
@@ -66,7 +66,6 @@
                                     v-model="formItems.aliasTarget"
                                     :mosaic-hex-ids="linkableMosaics"
                                     default-mosaic="firstInList"
-                                    label="form_label_link_mosaic"
                                 />
                             </template>
                         </FormRow>

--- a/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
+++ b/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
@@ -574,16 +574,9 @@ export class FormTransferTransactionTs extends FormTransactionBase {
         }
     }
 
-    /**
-     * Resetting the form when choosing a multisig signer and changing multisig signer
-     * Is necessary to make the mosaic inputs reactive
-     */
     @Watch('selectedSigner')
     onSelectedSignerChange() {
         this.formItems.signerAddress = this.selectedSigner.address.plain();
-        if (this.isMultisigMode()) {
-            this.resetForm();
-        }
     }
 
     /**


### PR DESCRIPTION
Reset was added in #55 but it is unclear why. It works without reset and this is more convenient (as noticed by @jabo38).

Also fixed validation error messages.