### PR TITLE
Increase scrollbar thumb width/height in Chrome and Electron

### DIFF
--- a/src/views/resources/css/forms.less
+++ b/src/views/resources/css/forms.less
@@ -862,3 +862,12 @@
 .clickable {
     cursor: pointer;
 }
+
+::-webkit-scrollbar {
+    width: 14px;
+    height: 14px;
+}
+
+::-webkit-scrollbar-thumb {
+    border-radius: 0;
+}


### PR DESCRIPTION
This fixes #658.