### PR TITLE
Fixed edit metadata mosaic

### DIFF
--- a/src/views/forms/FormMetadataCreation/FormMetadataCreation.vue
+++ b/src/views/forms/FormMetadataCreation/FormMetadataCreation.vue
@@ -61,10 +61,10 @@
                     </FormRow>
                     <div v-if="type === MetadataType.Namespace">
                         <NamespaceSelector
-                            v-model="formItems.targetId"
+                            v-model="formItems.targetName"
                             :namespaces="ownedTargetHexIds"
                             :disable-linked="false"
-                            label="targetLabel"
+                            :label="$t(targetLabel)"
                             :disabled="editMode"
                         />
                     </div>

--- a/src/views/forms/FormMetadataCreation/FormMetadataCreationTs.ts
+++ b/src/views/forms/FormMetadataCreation/FormMetadataCreationTs.ts
@@ -137,6 +137,7 @@ export class FormMetadataCreationTs extends FormTransactionBase {
         signerAddress: '',
         targetAccount: '',
         targetId: '',
+        targetName: '',
         metadataValue: '',
         scopedKey: '',
         maxFee: 0,
@@ -371,7 +372,8 @@ export class FormMetadataCreationTs extends FormTransactionBase {
         if (selectedItem) {
             this.formItems.signerAddress = selectedItem.sourceAddress;
             this.formItems.targetAccount = selectedItem.targetAddress;
-            this.formItems.targetId = this.targetNameById(selectedItem.targetId);
+            this.formItems.targetId = selectedItem.targetId;
+            this.formItems.targetName = this.targetNameById(selectedItem.targetId);
             this.formItems.metadataValue = selectedItem.value;
             this.formItems.scopedKey = selectedItem.scopedMetadataKey;
         }


### PR DESCRIPTION
When editing mosaic metadata, `Target Mosaic ID` was empty and not selectable.
Also fixed `Target Namespace ID` label in edit namespace metadata modal.