### PR TITLE
Reset account selection when starting import

### DIFF
--- a/src/store/Account.ts
+++ b/src/store/Account.ts
@@ -243,6 +243,12 @@ export default {
             selectedAccounts.splice(indexToDelete, 1);
             state.selectedAddressesOptInToInteract = selectedAccounts;
         },
+        resetSelectedAddressesToInteract: (state: AccountState) => {
+            state.selectedAddressesToInteract = [];
+        },
+        resetSelectedAddressesOptInToInteract: (state: AccountState) => {
+            state.selectedAddressesOptInToInteract = [];
+        },
         listener: (state: AccountState, listener: IListener) => Vue.set(state, 'listener', listener),
     },
     actions: {

--- a/src/views/pages/profiles/import-profile/ImportProfileTs.ts
+++ b/src/views/pages/profiles/import-profile/ImportProfileTs.ts
@@ -128,6 +128,8 @@ export default class ImportProfileTs extends Vue {
             setTimeout(() => this.initOptInAccounts(), 300);
         });
         await this.$store.dispatch('temporary/initialize');
+        this.$store.commit('account/resetSelectedAddressesToInteract');
+        this.$store.commit('account/resetSelectedAddressesOptInToInteract');
     }
 
     @Watch('selectedAccounts')


### PR DESCRIPTION
Fixes the following issue:

Steps to reproduce:
1. Import mnemonic and select one account and finish the import process
2. Logout without refreshing the browser window
3. Import mnemonic again
-> The previously selected account is still (invisibly) selected (not visible in the table on the right, not visible on the left).