### PR TITLE
Moved opt-in accounts logic from .env file to json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ __mocks__/**/*.js
 /.templates
 template.config.js
 .env
+keys-whitelist.json

--- a/src/views/pages/profiles/import-profile/ImportProfileTs.ts
+++ b/src/views/pages/profiles/import-profile/ImportProfileTs.ts
@@ -177,8 +177,8 @@ export default class ImportProfileTs extends Vue {
         );
 
         // whitelist opt in accounts
-        const key = this.currentProfile.networkType === NetworkType.MAIN_NET ? 'MAINNET' : 'TESTNET';
-        const whitelisted = process.env[`VUE_APP_${key}_WHITELIST`] ? process.env[`VUE_APP_${key}_WHITELIST`].split(',') : [];
+        const key = this.currentProfile.networkType === NetworkType.MAIN_NET ? 'mainnet' : 'testnet';
+        const whitelisted = process.env.KEYS_WHITELIST[key];
         const optInAccounts = possibleOptInAccounts.filter((account) => whitelisted.indexOf(account.publicKey) >= 0);
         if (optInAccounts.length === 0) {
             return;

--- a/src/views/pages/profiles/import-profile/account-selection/AccountSelectionTs.ts
+++ b/src/views/pages/profiles/import-profile/account-selection/AccountSelectionTs.ts
@@ -241,8 +241,8 @@ export default class AccountSelectionTs extends Vue {
         );
 
         // whitelist opt in accounts
-        const key = this.currentProfile.networkType === NetworkType.MAIN_NET ? 'MAINNET' : 'TESTNET';
-        const whitelisted = process.env[`VUE_APP_${key}_WHITELIST`] ? process.env[`VUE_APP_${key}_WHITELIST`].split(',') : [];
+        const key = this.currentProfile.networkType === NetworkType.MAIN_NET ? 'mainnet' : 'testnet';
+        const whitelisted = process.env.KEYS_WHITELIST[key];
         const optInAccounts = possibleOptInAccounts.filter((account) => whitelisted.indexOf(account.publicKey) >= 0);
         if (optInAccounts.length === 0) {
             return;

--- a/vue.config.js
+++ b/vue.config.js
@@ -25,10 +25,20 @@ module.exports = {
   chainWebpack: (config) => {
     config.plugin('define').tap((args) => {
       const env = args[0]['process.env'];
+      let keys;
+      try {
+        keys = require('./keys-whitelist.json');
+      } catch {
+        keys = {
+          mainnet: [],
+          testnet: []
+        }
+      }
       args[0]['process.env'] = {
           ...env,
           PACKAGE_VERSION: packageVersion,
           WEB: web,
+          KEYS_WHITELIST: JSON.stringify(keys)
       };
       return args;
     });


### PR DESCRIPTION
.env file couldn't support large files ( < 27k accounts ) logic is now moved to a json file called `keys-whitelist.json`

The format of the file is the following:

`{
  "mainnet": [
    "F530A00F5788DC3025E7F7F6000AF50C7A91283AFB1324E0E5D1BB494339EDE2"
  ],
  "testnet": [
    "F530A00F5788DC3025E7F7F6000AF50C7A91283AFB1324E0E5D1BB494339EDE2"
  ]
}`