### PR TITLE
Auto completion for recipient/account input

### DIFF
--- a/src/components/AccountAutoCompleteInput/AccountAutoCompleteInput.less
+++ b/src/components/AccountAutoCompleteInput/AccountAutoCompleteInput.less
@@ -1,0 +1,39 @@
+@import '../../views/resources/css/variables.less';
+
+.auto-complete {
+    padding: 0;
+
+    /deep/ input {
+        padding-left: 0.2rem;
+        padding-right: 0.24rem;
+        background: unset;
+    }
+}
+
+.auto-complete-group-title {
+    padding-left: 0.16rem;
+    margin-top: 0.05rem;
+    margin-bottom: 0.05rem;
+    font-weight: bold;
+    color: @primary;
+}
+
+.auto-complete-option-name {
+    color: @primary;
+    word-wrap: anywhere;
+}
+
+.auto-complete-option-address {
+    color: @grayDark;
+    float: right;
+}
+
+.auto-complete-option {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    column-gap: 0.2rem;
+}
+
+/deep/ .ivu-select-item-focus {
+    background-color: #e5e5e5;
+}

--- a/src/components/AccountAutoCompleteInput/AccountAutoCompleteInput.vue
+++ b/src/components/AccountAutoCompleteInput/AccountAutoCompleteInput.vue
@@ -1,0 +1,29 @@
+<template>
+    <AutoComplete
+        v-model="rawValue"
+        class="input-style auto-complete"
+        :placeholder="$t(placeholder)"
+        :transfer="true"
+        :disabled="disabled"
+        transfer-class-name="account-auto-complete-suggestions"
+    >
+        <div :style="autoCompletePopupStyle">
+            <div v-for="group in autoCompletionGroups" :key="group.title" class="auto-complete-group">
+                <div class="auto-complete-group-title">{{ $t(group.title) }}</div>
+                <Option v-for="item in group.items" :key="item.address" :value="item.address" class="auto-complete-option">
+                    <span class="auto-complete-option-name">{{ item.name }}</span>
+                    <span class="auto-complete-option-address">{{ item.address }}</span>
+                </Option>
+            </div>
+        </div>
+    </AutoComplete>
+</template>
+
+<script lang="ts">
+import { AccountAutoCompleteInputTs } from './AccountAutoCompleteInputTs';
+export default class AccountAutoCompleteInput extends AccountAutoCompleteInputTs {}
+</script>
+
+<style lang="less" scoped>
+@import './AccountAutoCompleteInput.less';
+</style>

--- a/src/components/AccountAutoCompleteInput/AccountAutoCompleteInputTs.ts
+++ b/src/components/AccountAutoCompleteInput/AccountAutoCompleteInputTs.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 NEM (https://nem.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+import { Component, Vue, Prop } from 'vue-property-decorator';
+import { mapGetters } from 'vuex';
+import { Address } from 'symbol-sdk';
+
+import { AddressBook } from 'symbol-address-book/AddressBook';
+import { AccountModel } from '@/core/database/entities/AccountModel';
+
+@Component({
+    computed: {
+        ...mapGetters({
+            addressBook: 'addressBook/getAddressBook',
+            knownAccounts: 'account/knownAccounts',
+            currentAccount: 'account/currentAccount',
+        }),
+    },
+    data: function () {
+        return {
+            autoCompletionGroups: [],
+        };
+    },
+    watch: {
+        value: {
+            handler: function (val) {
+                this.updateAutoCompletionGroups(val);
+            },
+        },
+    },
+})
+export class AccountAutoCompleteInputTs extends Vue {
+    @Prop({ default: null })
+    value: string;
+
+    @Prop({ default: false })
+    readonly disabled!: boolean;
+
+    @Prop({ default: '' })
+    placeholder: string;
+
+    @Prop({ default: undefined })
+    autocompletePopupMaxWidthInRem: number;
+
+    public get autoCompletePopupStyle(): string {
+        return this.autocompletePopupMaxWidthInRem ? `max-width: ${this.autocompletePopupMaxWidthInRem}rem;` : '';
+    }
+
+    /**
+     * Current address book
+     * @var {AddressBook}
+     */
+    public addressBook: AddressBook;
+
+    /**
+     * Known accounts identifiers
+     * @var {string[]}
+     */
+    public knownAccounts: AccountModel[];
+
+    /**
+     * Currently active account
+     * @see {Store.Account}
+     * @var {AccountModel}
+     */
+    public currentAccount: AccountModel;
+
+    public autoCompletionGroups: { title: string; items: { name: string; address: string }[] }[];
+
+    /// region computed properties getter/setter
+    public get rawValue(): string {
+        return this.value;
+    }
+
+    public set rawValue(input: string) {
+        this.$emit('input', input);
+    }
+    /// end-region computed properties getter/setter
+
+    public mounted(): void {
+        this.updateAutoCompletionGroups(this.rawValue);
+    }
+
+    public updateAutoCompletionGroups(recipientInput: string): void {
+        this.autoCompletionGroups = [];
+
+        const contacts = this.addressBook
+            .getAllContacts()
+            .filter(
+                (contact) =>
+                    contact.name.toLowerCase().includes(recipientInput) || contact.address.toLocaleLowerCase().includes(recipientInput),
+            )
+            .map((contact) => ({ name: contact.name, address: Address.createFromRawAddress(contact.address).pretty() }));
+
+        if (contacts.length) {
+            this.autoCompletionGroups.push({
+                title: 'recipient_input_contacts',
+                items: contacts,
+            });
+        }
+
+        const accounts = this.knownAccounts
+            .filter(
+                (account) =>
+                    this.currentAccount.id !== account.id &&
+                    (account.name.toLowerCase().includes(recipientInput) || account.address.toLocaleLowerCase().includes(recipientInput)),
+            )
+            .map((account) => ({ name: account.name, address: Address.createFromRawAddress(account.address).pretty() }));
+
+        if (accounts.length) {
+            this.autoCompletionGroups.push({
+                title: 'recipient_input_accounts',
+                items: accounts,
+            });
+        }
+    }
+}

--- a/src/components/AddCosignatoryInput/AddCosignatoryInput.vue
+++ b/src/components/AddCosignatoryInput/AddCosignatoryInput.vue
@@ -12,11 +12,10 @@
                 >
                     <div class="input-container">
                         <ErrorTooltip :errors="errors">
-                            <input
+                            <AccountAutoCompleteInput
                                 v-model="cosignatory"
-                                :placeholder="$t('placeholder_address_or_public_key')"
-                                class="input-style input-size"
-                                type="text"
+                                placeholder="placeholder_address_or_public_key"
+                                :autocomplete-popup-max-width-in-rem="7.2"
                                 @input="stripTagsCosignatory"
                             />
                         </ErrorTooltip>

--- a/src/components/AddCosignatoryInput/AddCosignatoryInputTs.ts
+++ b/src/components/AddCosignatoryInput/AddCosignatoryInputTs.ts
@@ -29,6 +29,8 @@ import FormRow from '@/components/FormRow/FormRow.vue';
 // @ts-ignore
 import ButtonAdd from '@/components/ButtonAdd/ButtonAdd.vue';
 import { FilterHelpers } from '@/core/utils/FilterHelpers';
+// @ts-ignore
+import AccountAutoCompleteInput from '@/components/AccountAutoCompleteInput/AccountAutoCompleteInput.vue';
 
 @Component({
     components: {
@@ -37,6 +39,7 @@ import { FilterHelpers } from '@/core/utils/FilterHelpers';
         ErrorTooltip,
         FormRow,
         ButtonAdd,
+        AccountAutoCompleteInput,
     },
     computed: {
         ...mapGetters({

--- a/src/components/RecipientInput/RecipientInput.vue
+++ b/src/components/RecipientInput/RecipientInput.vue
@@ -12,18 +12,13 @@
                 class="inputs-container"
             >
                 <ErrorTooltip :errors="errors">
-                    <input
+                    <AccountAutoCompleteInput
                         v-model="rawValue"
-                        v-focus
-                        class="input-size input-style"
-                        :placeholder="$t('placeholder_address_or_alias')"
-                        type="text"
+                        placeholder="placeholder_address_or_alias"
                         :disabled="disabled"
+                        :autocomplete-popup-max-width-in-rem="autocompletePopupMaxWidthInRem"
                     />
                 </ErrorTooltip>
-                <div v-if="!disabled && addressBook && addressBook.getAllContacts().length > 0" style="text-align: right; margin-top: 5px;">
-                    <ContactSelector @change="onSelectContact" />
-                </div>
             </ValidationProvider>
         </template>
     </FormRow>

--- a/src/components/RecipientInput/RecipientInputTs.ts
+++ b/src/components/RecipientInput/RecipientInputTs.ts
@@ -27,42 +27,36 @@ import ErrorTooltip from '@/components/ErrorTooltip/ErrorTooltip.vue';
 // @ts-ignore
 import FormRow from '@/components/FormRow/FormRow.vue';
 // @ts-ignore
-import ContactSelector from '@/components/ContactSelector/ContactSelector.vue';
-import { AddressBook } from 'symbol-address-book/AddressBook';
+import AccountAutoCompleteInput from '@/components/AccountAutoCompleteInput/AccountAutoCompleteInput.vue';
 
 @Component({
     components: {
         ValidationProvider,
         ErrorTooltip,
         FormRow,
-        ContactSelector,
+        AccountAutoCompleteInput,
     },
     computed: {
         ...mapGetters({
             networkType: 'network/networkType',
-            addressBook: 'addressBook/getAddressBook',
         }),
     },
 })
 export class RecipientInputTs extends Vue {
-    @Prop({
-        default: null,
-    })
+    @Prop({ default: null })
     value: string;
 
     @Prop({ default: false })
     readonly disabled!: boolean;
+
+    @Prop({ default: undefined })
+    autocompletePopupMaxWidthInRem: number;
 
     /**
      * Current network type
      * @var {NetworkType}
      */
     public networkType: NetworkType;
-    /**
-     * Current address book
-     * @var {AddressBook}
-     */
-    public addressBook: AddressBook;
 
     /**
      * Validation rules
@@ -79,11 +73,4 @@ export class RecipientInputTs extends Vue {
         this.$emit('input', input);
     }
     /// end-region computed properties getter/setter
-
-    public onSelectContact(id: string) {
-        const contact = this.addressBook.getContactById(id);
-        if (contact) {
-            this.rawValue = contact.address;
-        }
-    }
 }

--- a/src/language/en-US.json
+++ b/src/language/en-US.json
@@ -826,6 +826,8 @@
     "qrcode_detail_item_type_signedqr": "Signed transaction",
     "qrcode_password_info": "Uploaded QR Code is password protected. Please enter your password at the time this QR Code was generated.",
     "recipient": "Recipient",
+    "recipient_input_accounts": "My accounts",
+    "recipient_input_contacts": "My contacts",
     "recipient_linked_address_invalid": "The recipient's alias name does not have a linked address",
     "recipient_public_key_invalid_error": "Invalid recipient public key",
     "refresh": "Refresh",

--- a/src/language/ja-JP.json
+++ b/src/language/ja-JP.json
@@ -826,6 +826,8 @@
     "qrcode_detail_item_type_signedqr": "署名済みトランザクション",
     "qrcode_password_info": "アップロードされた QR コードはパスワードで保護されています。この QR コードが生成されたときのパスワードを入力してください。",
     "recipient": "受信者",
+    "recipient_input_accounts": "マイアカウント",
+    "recipient_input_contacts": "マイ連絡先",
     "recipient_linked_address_invalid": "受信者のエイリアス名にリンクされたアドレスがありません",
     "recipient_public_key_invalid_error": "無効な受信者公開鍵",
     "refresh": "更新",

--- a/src/language/zh-CN.json
+++ b/src/language/zh-CN.json
@@ -821,6 +821,8 @@
     "qrcode_detail_item_type_transactionqr": "发票",
     "qrcode_password_info": "上载的QR码受密码保护。\n请在生成此二维码时输入您的密码。",
     "recipient": "接收人",
+    "recipient_input_accounts": "我的帐户",
+    "recipient_input_contacts": "我的联系方式",
     "recipient_linked_address_invalid": "接受账户的别名没有链接的地址",
     "recipient_public_key_invalid_error": "接受人公匙不合法",
     "refresh": "刷新",

--- a/src/views/forms/FormAccountRestrictionTransaction/FormAccountRestrictionTransaction.vue
+++ b/src/views/forms/FormAccountRestrictionTransaction/FormAccountRestrictionTransaction.vue
@@ -11,7 +11,12 @@
                     <RestrictionTypeInput v-model="formItems.blockType" :disabled="isDeleteMode || transactionTypeDisabled" />
 
                     <!-- Transfer recipient input field -->
-                    <RecipientInput v-if="restrictionTxType === 'ADDRESS'" v-model="formItems.recipientRaw" :disabled="isDeleteMode" />
+                    <RecipientInput
+                        v-if="restrictionTxType === 'ADDRESS'"
+                        v-model="formItems.recipientRaw"
+                        :disabled="isDeleteMode"
+                        :autocomplete-popup-max-width-in-rem="6.3"
+                    />
 
                     <FormRow v-if="restrictionTxType === 'MOSAIC'" class-name="emphasis">
                         <template v-slot:label> {{ $t('mosaic_id') }}: </template>

--- a/src/views/forms/FormTransferTransaction/FormTransferTransaction.vue
+++ b/src/views/forms/FormTransferTransaction/FormTransferTransaction.vue
@@ -19,7 +19,12 @@
                     <AccountSignerSelector v-if="!hideSigner && isOfflineMode" />
 
                     <!-- Transfer recipient input field -->
-                    <RecipientInput v-model="formItems.recipientRaw" style="margin-bottom: 0.5rem;" @input="onChangeRecipient" />
+                    <RecipientInput
+                        v-model="formItems.recipientRaw"
+                        style="margin-bottom: 0.5rem;"
+                        :autocomplete-popup-max-width-in-rem="8"
+                        @input="onChangeRecipient"
+                    />
 
                     <!-- Mosaics attachments input fields -->
                     <div v-for="(attachedMosaic, index) in formItems.attachedMosaics" :key="index">


### PR DESCRIPTION
Replaced contact selector with auto completion. Also suggests own accounts (except currently selected account). Searches names and addresses. Displays all accounts and contacts when clicking in input box.

Also using this in multisig tx for adding cosignatories.

![grafik](https://user-images.githubusercontent.com/77545287/111917282-156ae380-8a77-11eb-96fd-5695a0f1b31a.png)