### PR TITLE
Aggregate Lock Funds Lost

### DIFF
--- a/src/core/database/entities/HashLockAggregatePairModel.ts
+++ b/src/core/database/entities/HashLockAggregatePairModel.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 NEM (https://nem.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+import { NetworkType, TransactionType } from 'symbol-sdk';
+
+/**
+ * HashLock Aggregate Pair to hold unspent HashLocks information
+ *
+ */
+export class HashLockAggregatePairModel {
+    public readonly profileName: string;
+    public readonly hashLockHash: string;
+    public readonly aggregateTransactionDTO: {
+        payload: string;
+        hash: string;
+        signerPublicKey: string;
+        type: TransactionType;
+        networkType: NetworkType;
+    };
+}

--- a/src/core/database/storage/HashLockAggregatePairModelStorage.ts
+++ b/src/core/database/storage/HashLockAggregatePairModelStorage.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 NEM (https://nem.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+import { VersionedObjectStorage } from '@/core/database/backends/VersionedObjectStorage';
+import { HashLockAggregatePairModel } from '@/core/database/entities/HashLockAggregatePairModel';
+
+/**
+ * Stored cache for the known block infos.
+ */
+export class HashLockAggregatePairModelStorage extends VersionedObjectStorage<HashLockAggregatePairModel[]> {
+    /**
+     * Singleton instance as we want to run the migration just once
+     */
+    public static INSTANCE = new HashLockAggregatePairModelStorage();
+
+    private constructor() {
+        super('addressBookPerProfile', [
+            {
+                description: 'Reset accounts for 0.10.0.5 network (non backwards compatible)',
+                migrate: () => undefined,
+            },
+            {
+                description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
+                migrate: () => undefined,
+            },
+        ]);
+    }
+}

--- a/src/services/TransactionAnnouncerService.ts
+++ b/src/services/TransactionAnnouncerService.ts
@@ -29,11 +29,15 @@ import {
     RepositoryFactory,
     SignedTransaction,
     Transaction,
+    TransactionGroup,
     TransactionService,
     TransactionType,
 } from 'symbol-sdk';
 import { TransactionAnnounceResponse } from 'symbol-sdk/dist/src/model/transaction/TransactionAnnounceResponse';
 import { Store } from 'vuex';
+import { HashLockAggregatePairModelStorage } from '@/core/database/storage/HashLockAggregatePairModelStorage';
+import { HashLockAggregatePairModel } from '@/core/database/entities/HashLockAggregatePairModel';
+import { ProfileModel } from '@/core/database/entities/ProfileModel';
 
 const { ANNOUNCE_TRANSACTION_TIMEOUT } = appConfig.constants;
 
@@ -68,6 +72,11 @@ export class TransactionAnnouncerService {
     private networkType: NetworkType;
 
     /**
+     * The namespace information local cache.
+     */
+    private readonly hashLockAggregatePairModelStorage = HashLockAggregatePairModelStorage.INSTANCE;
+
+    /**
      * Construct a service instance around \a store
      * @param store
      */
@@ -81,6 +90,15 @@ export class TransactionAnnouncerService {
         const service = this.createService();
         return service
             .announce(signedTransaction, listener)
+            .pipe(this.timeout(this.timeoutMessage(signedTransaction.type)))
+            .pipe(map((t) => this.createBroadcastResult(signedTransaction, t)));
+    }
+
+    public announceAggregateBonded(signedTransaction: SignedTransaction): Observable<BroadcastResult> {
+        const listener: IListener = this.$store.getters['account/listener'];
+        const service = this.createService();
+        return service
+            .announceAggregateBonded(signedTransaction, listener)
             .pipe(this.timeout(this.timeoutMessage(signedTransaction.type)))
             .pipe(map((t) => this.createBroadcastResult(signedTransaction, t)));
     }
@@ -118,6 +136,7 @@ export class TransactionAnnouncerService {
     ): Observable<BroadcastResult> {
         const repositoryFactory = this.$store.getters['network/repositoryFactory'] as RepositoryFactory;
         const hashLockListener: IListener = repositoryFactory.createListener();
+        this.addHashLockAggregateBondedPair(signedHashLockTransaction.hash, signedAggregateTransaction);
         return from(hashLockListener.open()).pipe(
             switchMap(() => {
                 hashLockListener.unconfirmedAdded(this.$store.getters['account/currentAccountAddress']);
@@ -141,6 +160,88 @@ export class TransactionAnnouncerService {
                     .pipe(map((t) => this.createBroadcastResult(signedAggregateTransaction, t)));
             }),
         );
+    }
+
+    private addHashLockAggregateBondedPair(hashLockHash: string, aggregateBonded: SignedTransaction): void {
+        const currentProfile: ProfileModel = this.$store.getters['profile/currentProfile'];
+        const hashLockAggregatePairs = this.hashLockAggregatePairModelStorage.get() || [];
+        hashLockAggregatePairs.push({
+            profileName: currentProfile.profileName,
+            hashLockHash: hashLockHash,
+            aggregateTransactionDTO: aggregateBonded.toDTO(),
+        } as HashLockAggregatePairModel);
+        this.hashLockAggregatePairModelStorage.set(hashLockAggregatePairs);
+    }
+
+    public async sendUnspentHashLockPairs(): Promise<void> {
+        const currentProfile: ProfileModel = this.$store.getters['profile/currentProfile'];
+        if (!currentProfile) {
+            return;
+        }
+        const hashLockAggregatePairs = this.hashLockAggregatePairModelStorage.get() || [];
+        const unannouncedPairs: HashLockAggregatePairModel[] = [];
+        for (const hashLockAggregatePair of hashLockAggregatePairs) {
+            const hashLockGroup = await this.getTransactionGroup(hashLockAggregatePair.hashLockHash);
+            if (!hashLockGroup === null) {
+                continue;
+            }
+            if (hashLockGroup === TransactionGroup.Unconfirmed) {
+                unannouncedPairs.push(hashLockAggregatePair);
+                continue;
+            }
+            const isAnnounced = await this.getTransactionGroup(hashLockAggregatePair.aggregateTransactionDTO.hash);
+            const signedTransaction = new SignedTransaction(
+                hashLockAggregatePair.aggregateTransactionDTO.payload,
+                hashLockAggregatePair.aggregateTransactionDTO.hash,
+                hashLockAggregatePair.aggregateTransactionDTO.signerPublicKey,
+                hashLockAggregatePair.aggregateTransactionDTO.type,
+                hashLockAggregatePair.aggregateTransactionDTO.networkType,
+            );
+            if (isAnnounced !== null) {
+                continue;
+            }
+            this.announceAggregateBonded(signedTransaction).subscribe(
+                (res) => {
+                    if (res.success) {
+                        this.$store.dispatch('notification/ADD_SUCCESS', 'success_transactions_announced');
+                    } else if (res.error) {
+                        this.$store.dispatch('notification/ADD_ERROR', res.error);
+                    }
+                },
+                (error) => {
+                    this.$store.dispatch('notification/ADD_ERROR', error);
+                },
+            );
+            unannouncedPairs.push(hashLockAggregatePair);
+        }
+        this.hashLockAggregatePairModelStorage.set(unannouncedPairs);
+    }
+
+    private async getTransactionGroup(hash: string): Promise<TransactionGroup | null> {
+        const repositoryFactory: RepositoryFactory = this.$store.getters['network/repositoryFactory'];
+        const transactionHttp = repositoryFactory.createTransactionRepository();
+        try {
+            const transaction = await transactionHttp.getTransaction(hash, TransactionGroup.Confirmed).toPromise();
+            if (transaction) {
+                return TransactionGroup.Confirmed;
+            }
+            // eslint-disable-next-line no-empty
+        } catch {}
+        try {
+            const transaction = await transactionHttp.getTransaction(hash, TransactionGroup.Partial).toPromise();
+            if (transaction) {
+                return TransactionGroup.Partial;
+            }
+            // eslint-disable-next-line no-empty
+        } catch {}
+        try {
+            const transaction = await transactionHttp.getTransaction(hash, TransactionGroup.Unconfirmed).toPromise();
+            if (transaction) {
+                return TransactionGroup.Unconfirmed;
+            }
+            // eslint-disable-next-line no-empty
+        } catch {}
+        return null;
     }
 
     public announceChainedBinary(first: SignedTransaction, second: SignedTransaction): Observable<BroadcastResult> {


### PR DESCRIPTION
Resolved #1383 Aggregate Lock Funds lost

The fix implies of saving hash lock <-> aggregate transaction pairs into storage when a bonded transaction is made.

There's a background job that checks the storage for unannounced/failed aggregate transactions that runs every 10 seconds and if it finds a transaction that is lost it broadcasts it.