### PR TITLE
New testnet Configuration

### DIFF
--- a/__tests__/database/backends/VersionedObjectStorage.spec.ts
+++ b/__tests__/database/backends/VersionedObjectStorage.spec.ts
@@ -20,7 +20,7 @@ describe('database/SimpleObjectStorage.spec ==>', () => {
     describe('constructor() should', () => {
         test('Get/Set/Delete', () => {
             const storageKey = 'someTable';
-            const storage1 = new VersionedObjectStorage<number>(storageKey);
+            const storage1 = new VersionedObjectStorage<number>({ storageKey: storageKey });
             expect(storage1.get()).toBeUndefined();
             expect(storage1.getVersion()).toBeUndefined();
             storage1.set(123);
@@ -35,7 +35,7 @@ describe('database/SimpleObjectStorage.spec ==>', () => {
 
         test('Get/Set/Delete Migration', () => {
             const storageKey = 'someTable';
-            const storage1 = new VersionedObjectStorage<number>(storageKey);
+            const storage1 = new VersionedObjectStorage<number>({ storageKey: storageKey });
             storage1.set(123);
             expect(storage1.getVersion()).toBe(1);
             expect(storage1.get()).toBe(123);
@@ -61,17 +61,26 @@ describe('database/SimpleObjectStorage.spec ==>', () => {
                 },
             };
             // Migrate to string
-            const storage2 = new VersionedObjectStorage<string>(storageKey, [migration1]);
+            const storage2 = new VersionedObjectStorage<string>({
+                storageKey: storageKey,
+                migrations: [migration1],
+            });
             expect(storage2.get()).toBe('123');
             expect(storage2.getVersion()).toBe(2);
 
             // No Migration
-            const storage3 = new VersionedObjectStorage<string>(storageKey, [migration1]);
+            const storage3 = new VersionedObjectStorage<string>({
+                storageKey: storageKey,
+                migrations: [migration1],
+            });
             expect(storage3.get()).toBe('123');
             expect(storage3.getVersion()).toBe(2);
 
             // Double Migration (append A and append Z)
-            const storage4 = new VersionedObjectStorage<string>(storageKey, [migration1, migration2, migration3]);
+            const storage4 = new VersionedObjectStorage<string>({
+                storageKey: storageKey,
+                migrations: [migration1, migration2, migration3],
+            });
             expect(storage4.get()).toBe('123AZ');
             expect(storage4.getVersion()).toBe(4);
         });

--- a/__tests__/database/storage/ProfileModelStorage.spec.ts
+++ b/__tests__/database/storage/ProfileModelStorage.spec.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2020 NEM Foundation (https://nem.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ *
+ */
+
+import { NetworkType } from 'symbol-sdk';
+import { ProfileModelStorage } from '@/core/database/storage/ProfileModelStorage';
+import { ObjectStorageBackend } from '@/core/database/backends/ObjectStorageBackend';
+import { SimpleObjectStorage } from '@/core/database/backends/SimpleObjectStorage';
+import { VersionedModel } from '@/core/database/entities/VersionedModel';
+import { ProfileModel } from '@/core/database/entities/ProfileModel';
+import { defaultTestnetNetworkConfig } from '@/config';
+
+describe('storage/ProfileModelStorage.spec ==>', () => {
+    describe('constructor() should', () => {
+        test('Should upgrade testnet only on v8', () => {
+            const profiles = {
+                version: 7,
+                data: {
+                    someMainnetProfile: {
+                        profileName: 'someMainnetProfile',
+                        accounts: ['1', '2', '3'],
+                        seed: 'SomeSeed2',
+                        password: 'myPassword2',
+                        hint: '',
+                        networkType: NetworkType.MAIN_NET,
+                        generationHash: '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6',
+                        termsAndConditionsApproved: false,
+                        selectedNodeUrlToConnect: 'http://ngl-dual-001.symbolblockchain.io:3000',
+                    },
+                    someTestnetProfile: {
+                        profileName: 'someTestnetProfile',
+                        accounts: ['a', 'b', 'c'],
+                        seed: 'SomeSeed',
+                        password: 'myPassword',
+                        hint: '',
+                        networkType: NetworkType.TEST_NET,
+                        generationHash: '45FBCF2F0EA36EFA7923C9BC923D6503169651F7FA4EFC46A8EAF5AE09057EBD',
+                        termsAndConditionsApproved: false,
+                        selectedNodeUrlToConnect: 'http://api-01.us-west-1.testnet.symboldev.network:3000',
+                    },
+                    somePrivateNetwork: {
+                        profileName: 'somePrivateNetwork',
+                        accounts: ['1a', '2b', '3c'],
+                        seed: 'SomeSeed3',
+                        password: 'myPassword3',
+                        hint: '',
+                        networkType: NetworkType.PRIVATE_TEST,
+                        generationHash: 'AAAADA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6',
+                        termsAndConditionsApproved: false,
+                        selectedNodeUrlToConnect: 'http://private.network:3000',
+                    },
+                },
+            };
+            const delegate = new SimpleObjectStorage<VersionedModel<Record<string, ProfileModel>>>(
+                'profiles',
+                new ObjectStorageBackend({
+                    profiles: JSON.stringify(profiles),
+                }),
+            );
+            const storage = new ProfileModelStorage(delegate);
+            const migratedData = storage.get();
+            const expected = {
+                someMainnetProfile: {
+                    profileName: 'someMainnetProfile',
+                    accounts: ['1', '2', '3'],
+                    seed: 'SomeSeed2',
+                    password: 'myPassword2',
+                    hint: '',
+                    networkType: NetworkType.MAIN_NET,
+                    generationHash: '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6',
+                    termsAndConditionsApproved: false,
+                    selectedNodeUrlToConnect: 'http://ngl-dual-001.symbolblockchain.io:3000',
+                },
+                someTestnetProfile: {
+                    profileName: 'someTestnetProfile',
+                    accounts: ['a', 'b', 'c'],
+                    seed: 'SomeSeed',
+                    password: 'myPassword',
+                    hint: '',
+                    networkType: NetworkType.TEST_NET,
+                    generationHash: '3B5E1FA6445653C971A50687E75E6D09FB30481055E3990C84B25E9222DC1155',
+                    termsAndConditionsApproved: false,
+                    selectedNodeUrlToConnect: migratedData.someTestnetProfile.selectedNodeUrlToConnect,
+                },
+                somePrivateNetwork: {
+                    profileName: 'somePrivateNetwork',
+                    accounts: ['1a', '2b', '3c'],
+                    seed: 'SomeSeed3',
+                    password: 'myPassword3',
+                    hint: '',
+                    networkType: NetworkType.PRIVATE_TEST,
+                    generationHash: 'AAAADA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6',
+                    termsAndConditionsApproved: false,
+                    selectedNodeUrlToConnect: 'http://private.network:3000',
+                },
+            };
+
+            expect(
+                defaultTestnetNetworkConfig.nodes.find((n) => n.url === migratedData.someTestnetProfile.selectedNodeUrlToConnect),
+            ).toBeDefined();
+            expect(migratedData).toEqual(expected);
+        });
+
+        test('Should not upgrade, testnet already v8', () => {
+            const profiles = {
+                version: 7,
+                data: {
+                    someMainnetProfile: {
+                        profileName: 'someMainnetProfile',
+                        accounts: ['1', '2', '3'],
+                        seed: 'SomeSeed2',
+                        password: 'myPassword2',
+                        hint: '',
+                        networkType: NetworkType.MAIN_NET,
+                        generationHash: '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6',
+                        termsAndConditionsApproved: false,
+                        selectedNodeUrlToConnect: 'http://ngl-dual-001.symbolblockchain.io:3000',
+                    },
+                    someTestnetProfile: {
+                        profileName: 'someTestnetProfile',
+                        accounts: ['a', 'b', 'c'],
+                        seed: 'SomeSeed',
+                        password: 'myPassword',
+                        hint: '',
+                        networkType: NetworkType.TEST_NET,
+                        generationHash: '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6',
+                        termsAndConditionsApproved: false,
+                        selectedNodeUrlToConnect: 'http://api-01.testnet.symboldev.network:3000',
+                    },
+                    somePrivateNetwork: {
+                        profileName: 'somePrivateNetwork',
+                        accounts: ['1a', '2b', '3c'],
+                        seed: 'SomeSeed3',
+                        password: 'myPassword3',
+                        hint: '',
+                        networkType: NetworkType.PRIVATE_TEST,
+                        generationHash: '3B5E1FA6445653C971A50687E75E6D09FB30481055E3990C84B25E9222DC1155',
+                        termsAndConditionsApproved: false,
+                        selectedNodeUrlToConnect: 'http://private.network:3000',
+                    },
+                },
+            };
+            const delegate = new SimpleObjectStorage<VersionedModel<Record<string, ProfileModel>>>(
+                'profiles',
+                new ObjectStorageBackend({
+                    profiles: JSON.stringify(profiles),
+                }),
+            );
+            const storage = new ProfileModelStorage(delegate);
+            const migratedData = storage.get();
+            expect(migratedData).toEqual(profiles.data);
+        });
+    });
+});

--- a/__tests__/database/storage/ProfileModelStorage.spec.ts
+++ b/__tests__/database/storage/ProfileModelStorage.spec.ts
@@ -115,7 +115,7 @@ describe('storage/ProfileModelStorage.spec ==>', () => {
 
         test('Should not upgrade, testnet already v8', () => {
             const profiles = {
-                version: 7,
+                version: 8,
                 data: {
                     someMainnetProfile: {
                         profileName: 'someMainnetProfile',

--- a/__tests__/database/storage/ProfileModelStorage.spec.ts
+++ b/__tests__/database/storage/ProfileModelStorage.spec.ts
@@ -111,6 +111,7 @@ describe('storage/ProfileModelStorage.spec ==>', () => {
                 defaultTestnetNetworkConfig.nodes.find((n) => n.url === migratedData.someTestnetProfile.selectedNodeUrlToConnect),
             ).toBeDefined();
             expect(migratedData).toEqual(expected);
+            expect(delegate.get()).toEqual({ version: 8, data: migratedData });
         });
 
         test('Should not upgrade, testnet already v8', () => {
@@ -161,6 +162,7 @@ describe('storage/ProfileModelStorage.spec ==>', () => {
             const storage = new ProfileModelStorage(delegate);
             const migratedData = storage.get();
             expect(migratedData).toEqual(profiles.data);
+            expect(delegate.get()).toEqual(profiles);
         });
     });
 });

--- a/src/config/NetworkConfig.ts
+++ b/src/config/NetworkConfig.ts
@@ -50,41 +50,43 @@ export interface NetworkConfig {
     networkConfigurationDefaults: NetworkConfigurationDefaults;
 }
 
-const defaultTestnetNetworkConfig: NetworkConfig = {
+export const defaultTestnetNetworkConfig: NetworkConfig = {
     explorerUrl: 'http://explorer.testnet.symboldev.network/',
     faucetUrl: 'http://faucet.testnet.symboldev.network/',
     defaultNetworkType: 152,
     networkConfigurationDefaults: {
         maxMosaicDivisibility: 6,
-        namespaceGracePeriodDuration: 2592000,
+        namespaceGracePeriodDuration: 86400,
         lockedFundsPerAggregate: '10000000',
         maxCosignatoriesPerAccount: 25,
         blockGenerationTargetTime: 30,
         maxNamespaceDepth: 3,
         maxMosaicDuration: 315360000,
         minNamespaceDuration: 2592000,
-        maxNamespaceDuration: 5256000,
+        maxNamespaceDuration: 157680000,
         maxTransactionsPerAggregate: 100,
         maxCosignedAccountsPerAccount: 25,
         maxMessageSize: 1024,
-        maxMosaicAtomicUnits: 9000000000000000,
-        currencyMosaicId: '2CF403E85507F39E',
-        harvestingMosaicId: '2CF403E85507F39E',
-        defaultDynamicFeeMultiplier: 1000,
-        epochAdjustment: 1573430400,
-        totalChainImportance: undefined,
-        generationHash: '45FBCF2F0EA36EFA7923C9BC923D6503169651F7FA4EFC46A8EAF5AE09057EBD',
+        maxMosaicAtomicUnits: 8999999999000000,
+        currencyMosaicId: '091F837E059AE13C',
+        harvestingMosaicId: '091F837E059AE13C',
+        defaultDynamicFeeMultiplier: 100,
+        epochAdjustment: 1616694977,
+        totalChainImportance: 7842928625000000,
+        generationHash: '3B5E1FA6445653C971A50687E75E6D09FB30481055E3990C84B25E9222DC1155',
     },
     nodes: [
-        { friendlyName: 'API North East 1', roles: 2, url: 'http://api-01.ap-northeast-1.testnet.symboldev.network:3000' },
-        { friendlyName: 'API South West 1', roles: 2, url: 'http://api-01.ap-southeast-1.testnet.symboldev.network:3000' },
-        { friendlyName: 'API EU Central 1', roles: 2, url: 'http://api-01.eu-central-1.testnet.symboldev.network:3000' },
-        { friendlyName: 'API EU West 1', roles: 2, url: 'http://api-01.eu-west-1.testnet.symboldev.network:3000' },
-        { friendlyName: 'API US West 1', roles: 2, url: 'http://api-01.us-west-1.testnet.symboldev.network:3000' },
+        { friendlyName: 'ngl-dual-001', roles: 2, url: 'http://ngl-dual-001.testnet.symboldev.network:3000' },
+        { friendlyName: 'ngl-dual-101', roles: 2, url: 'http://ngl-dual-101.testnet.symboldev.network:3000' },
+        { friendlyName: 'ngl-dual-201', roles: 2, url: 'http://ngl-dual-201.testnet.symboldev.network:3000' },
+        { friendlyName: 'ngl-dual-301', roles: 2, url: 'http://ngl-dual-301.testnet.symboldev.network:3000' },
+        { friendlyName: 'ngl-dual-401', roles: 2, url: 'http://ngl-dual-401.testnet.symboldev.network:3000' },
+        { friendlyName: 'ngl-dual-501', roles: 2, url: 'http://ngl-dual-501.testnet.symboldev.network:3000' },
+        { friendlyName: 'ngl-dual-601', roles: 2, url: 'http://ngl-dual-601.testnet.symboldev.network:3000' },
     ],
 };
 
-const defaultMainnetNetworkConfig: NetworkConfig = {
+export const defaultMainnetNetworkConfig: NetworkConfig = {
     explorerUrl: 'http://explorer.symbolblockchain.io/',
     faucetUrl: 'http://faucet.mainnet.symboldev.network/',
     defaultNetworkType: 104,

--- a/src/core/database/backends/IStorageBackend.ts
+++ b/src/core/database/backends/IStorageBackend.ts
@@ -25,14 +25,14 @@ export interface IStorageBackend {
      * @param {string} key
      * @return {string|null}
      */
-    getItem(key: string): any;
+    getItem(key: string): string | null;
 
     /**
      * Setter for \a key with \a value
      * @param {string} key
      * @param {any} value
      */
-    setItem(key: string, value: any): void;
+    setItem(key: string, value: string): void;
 
     /**
      * Deletes the value for the given key

--- a/src/core/database/backends/LocalStorageBackend.ts
+++ b/src/core/database/backends/LocalStorageBackend.ts
@@ -38,7 +38,7 @@ export class LocalStorageBackend implements IStorageBackend {
      * @param {string} key
      * @return {any}
      */
-    public getItem(key: string): any {
+    public getItem(key: string): string | undefined {
         return localStorage.getItem(key);
     }
 
@@ -47,7 +47,7 @@ export class LocalStorageBackend implements IStorageBackend {
      * @param {string} key
      * @param {any} value
      */
-    public setItem(key: string, value: any): void {
+    public setItem(key: string, value: string): void {
         localStorage.setItem(key, value);
     }
 

--- a/src/core/database/backends/ObjectStorageBackend.ts
+++ b/src/core/database/backends/ObjectStorageBackend.ts
@@ -16,20 +16,12 @@
 // internal dependencies
 import { IStorageBackend } from './IStorageBackend';
 
-export class ObjectStorageBackend implements IStorageBackend {
-    /**
-     * The storage backend (a simple object)
-     * @var {any}
-     */
-    protected backend: any = {};
-
+export class ObjectStorageBackend<T> implements IStorageBackend {
     /**
      * Construct an object storage backend
      * @param backend
      */
-    public constructor(backend: any = {}) {
-        this.backend = backend;
-    }
+    public constructor(protected readonly backend: Record<string, string> = {}) {}
 
     /**
      * The number of available entries
@@ -52,7 +44,7 @@ export class ObjectStorageBackend implements IStorageBackend {
      * @param {string} key
      * @return {any}
      */
-    public getItem(key: string): any {
+    public getItem(key: string): string | null {
         if (!this.backend || !this.backend[key]) {
             return null;
         }
@@ -65,7 +57,7 @@ export class ObjectStorageBackend implements IStorageBackend {
      * @param {string} key
      * @param {any} value
      */
-    public setItem(key: string, value: any): void {
+    public setItem(key: string, value: string): void {
         this.backend[key] = value;
     }
 

--- a/src/core/database/backends/SimpleObjectStorage.ts
+++ b/src/core/database/backends/SimpleObjectStorage.ts
@@ -33,11 +33,11 @@ export class SimpleObjectStorage<E> implements IStorage<E> {
     /**
      * The Storage backend, if localStorage is not available the storage will be in memory.
      */
-    private readonly storageBackend: IStorageBackend;
 
-    public constructor(private readonly storageKey) {
-        this.storageBackend = !!localStorage ? new LocalStorageBackend() : new ObjectStorageBackend();
-    }
+    public constructor(
+        private readonly storageKey: string,
+        private readonly storageBackend: IStorageBackend = !!localStorage ? new LocalStorageBackend() : new ObjectStorageBackend(),
+    ) {}
 
     /**
      * @return the stored value or undefined

--- a/src/core/database/backends/VersionedNetworkBasedObjectStorage.ts
+++ b/src/core/database/backends/VersionedNetworkBasedObjectStorage.ts
@@ -25,6 +25,11 @@ import { NetworkBasedModel } from '@/core/database/entities/NetworkBasedModel';
  */
 export class VersionedNetworkBasedObjectStorage<E> extends NetworkBasedObjectStorage<E> implements INetworkBasedStorage<E> {
     constructor(storageKey: string, migrations: Migration[] = []) {
-        super(new VersionedObjectStorage<NetworkBasedModel<E>>(storageKey, migrations));
+        super(
+            new VersionedObjectStorage<NetworkBasedModel<E>>({
+                storageKey: storageKey,
+                migrations: migrations,
+            }),
+        );
     }
 }

--- a/src/core/database/backends/VersionedObjectStorage.ts
+++ b/src/core/database/backends/VersionedObjectStorage.ts
@@ -36,8 +36,19 @@ export class VersionedObjectStorage<E> implements IStorage<E> {
 
     private readonly currentVersion: number;
 
-    constructor(storageKey: string, migrations: Migration[] = []) {
-        this.delegate = new SimpleObjectStorage<VersionedModel<E>>(storageKey);
+    constructor({
+        delegate,
+        storageKey,
+        migrations = [],
+    }: {
+        delegate?: IStorage<VersionedModel<E>>;
+        storageKey?: string;
+        migrations?: Migration[];
+    }) {
+        if (!delegate && !storageKey) {
+            throw new Error('delegate or storage key must be provided!');
+        }
+        this.delegate = delegate || new SimpleObjectStorage<VersionedModel<E>>(storageKey);
         this.currentVersion = migrations.length + 1;
         const versioned = this.delegate.get();
         if (!versioned || versioned.version == this.currentVersion) {

--- a/src/core/database/storage/AccountModelStorage.ts
+++ b/src/core/database/storage/AccountModelStorage.ts
@@ -26,91 +26,99 @@ export class AccountModelStorage extends VersionedObjectStorage<Record<string, A
     public static INSTANCE = new AccountModelStorage();
 
     private constructor() {
-        super('accounts', [
-            {
-                description: 'Update accounts to hold encRemoteAccountPrivateKey',
-                migrate: (from: any) => {
-                    // update all accounts
-                    const accounts = Object.keys(from);
+        super({
+            storageKey: 'accounts',
+            migrations: [
+                {
+                    description: 'Update accounts to hold encRemoteAccountPrivateKey',
+                    migrate: (from: any) => {
+                        // update all accounts
+                        const accounts = Object.keys(from);
 
-                    const modified: any = from;
-                    accounts.map((name: string) => {
-                        modified[name] = {
-                            ...modified[name],
-                            encRemoteAccountPrivateKey: '',
-                        };
-                    });
+                        const modified: any = from;
+                        accounts.map((name: string) => {
+                            modified[name] = {
+                                ...modified[name],
+                                encRemoteAccountPrivateKey: '',
+                            };
+                        });
 
-                    return modified;
+                        return modified;
+                    },
                 },
-            },
-            {
-                description: 'Update accounts for 0.9.6.3 network (address changes)',
-                migrate: (from: any) => {
-                    // update all pre-0.9.6.x profiles
-                    const profiles = Object.keys(from);
+                {
+                    description: 'Update accounts for 0.9.6.3 network (address changes)',
+                    migrate: (from: any) => {
+                        // update all pre-0.9.6.x profiles
+                        const profiles = Object.keys(from);
 
-                    const modified: any = from;
-                    profiles.map((name: string) => {
-                        modified[name] = {
-                            ...modified[name],
-                            // re-generating address from public key (0.9.6.x changes in addresses format)
-                            address: Address.createFromPublicKey(modified[name].publicKey, modified[name].networkType).plain(),
-                        };
-                    });
+                        const modified: any = from;
+                        profiles.map((name: string) => {
+                            modified[name] = {
+                                ...modified[name],
+                                // re-generating address from public key (0.9.6.x changes in addresses format)
+                                address: Address.createFromPublicKey(modified[name].publicKey, modified[name].networkType).plain(),
+                            };
+                        });
 
-                    return modified;
+                        return modified;
+                    },
                 },
-            },
-            {
-                description: 'Reset accounts for 0.9.6.3 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Update accounts to move harvesting fields to HarvestingModelStorage',
-                migrate: (from: any) => {
-                    const harvestingService = new HarvestingService();
+                {
+                    description: 'Reset accounts for 0.9.6.3 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Update accounts to move harvesting fields to HarvestingModelStorage',
+                    migrate: (from: any) => {
+                        const harvestingService = new HarvestingService();
 
-                    // update all accounts
-                    const accounts = Object.keys(from);
+                        // update all accounts
+                        const accounts = Object.keys(from);
 
-                    const modified: any = from;
-                    accounts.map((name: string) => {
-                        const {
-                            address,
-                            isPersistentDelReqSent,
-                            selectedHarvestingNode,
-                            encRemotePrivateKey,
-                            encVrfPrivateKey,
-                            ...nonHarvesting
-                        } = modified[name];
-
-                        try {
-                            harvestingService.saveHarvestingModel({
-                                accountAddress: address,
+                        const modified: any = from;
+                        accounts.map((name: string) => {
+                            const {
+                                address,
                                 isPersistentDelReqSent,
                                 selectedHarvestingNode,
                                 encRemotePrivateKey,
                                 encVrfPrivateKey,
-                                ...nonHarvesting,
-                            });
-                            modified[name] = { address, encRemotePrivateKey, encVrfPrivateKey, ...nonHarvesting };
-                        } catch (error) {
-                            console.log(error);
-                        }
-                    });
+                                ...nonHarvesting
+                            } = modified[name];
 
-                    return modified;
+                            try {
+                                harvestingService.saveHarvestingModel({
+                                    accountAddress: address,
+                                    isPersistentDelReqSent,
+                                    selectedHarvestingNode,
+                                    encRemotePrivateKey,
+                                    encVrfPrivateKey,
+                                    ...nonHarvesting,
+                                });
+                                modified[name] = {
+                                    address,
+                                    encRemotePrivateKey,
+                                    encVrfPrivateKey,
+                                    ...nonHarvesting,
+                                };
+                            } catch (error) {
+                                console.log(error);
+                            }
+                        });
+
+                        return modified;
+                    },
                 },
-            },
-            {
-                description: 'Reset accounts for 0.10.0.5 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-        ]);
+                {
+                    description: 'Reset accounts for 0.10.0.5 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+            ],
+        });
     }
 }

--- a/src/core/database/storage/AddressBookModelStorage.ts
+++ b/src/core/database/storage/AddressBookModelStorage.ts
@@ -26,15 +26,18 @@ export class AddressBookModelStorage extends VersionedObjectStorage<Record<strin
     public static INSTANCE = new AddressBookModelStorage();
 
     private constructor() {
-        super('addressBookPerProfile', [
-            {
-                description: 'Reset accounts for 0.10.0.5 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-        ]);
+        super({
+            storageKey: 'addressBookPerProfile',
+            migrations: [
+                {
+                    description: 'Reset accounts for 0.10.0.5 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+            ],
+        });
     }
 }

--- a/src/core/database/storage/HarvestingModelStorage.ts
+++ b/src/core/database/storage/HarvestingModelStorage.ts
@@ -24,15 +24,18 @@ export class HarvestingModelStorage extends VersionedObjectStorage<HarvestingMod
     public static INSTANCE = new HarvestingModelStorage();
 
     private constructor() {
-        super('harvestingModels', [
-            {
-                description: 'Reset accounts for 0.10.0.5 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-        ]);
+        super({
+            storageKey: 'harvestingModels',
+            migrations: [
+                {
+                    description: 'Reset accounts for 0.10.0.5 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+            ],
+        });
     }
 }

--- a/src/core/database/storage/MosaicConfigurationModelStorage.ts
+++ b/src/core/database/storage/MosaicConfigurationModelStorage.ts
@@ -23,15 +23,18 @@ export class MosaicConfigurationModelStorage extends VersionedObjectStorage<Reco
     public static INSTANCE = new MosaicConfigurationModelStorage();
 
     private constructor() {
-        super('mosaicConfiguration', [
-            {
-                description: 'Reset accounts for 0.10.0.5 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-        ]);
+        super({
+            storageKey: 'mosaicConfiguration',
+            migrations: [
+                {
+                    description: 'Reset accounts for 0.10.0.5 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+            ],
+        });
     }
 }

--- a/src/core/database/storage/NodeModelStorage.ts
+++ b/src/core/database/storage/NodeModelStorage.ts
@@ -24,35 +24,38 @@ export class NodeModelStorage extends VersionedObjectStorage<NodeModel[]> {
     public static INSTANCE = new NodeModelStorage();
 
     private constructor() {
-        super('node', [
-            {
-                description: 'Update node to 0.9.5.1 network',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Update node for 0.9.6.3 network (known nodes)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Update node for 0.10.x network (known nodes)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Reset accounts for 0.10.0.5 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Reset accounts for 0.10.0.7 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Reset accounts for 1.0.0.0 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-        ]);
+        super({
+            storageKey: 'node',
+            migrations: [
+                {
+                    description: 'Update node to 0.9.5.1 network',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Update node for 0.9.6.3 network (known nodes)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Update node for 0.10.x network (known nodes)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Reset accounts for 0.10.0.5 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Reset accounts for 0.10.0.7 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Reset accounts for 1.0.0.0 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+            ],
+        });
     }
 }

--- a/src/core/database/storage/ProfileModelStorage.ts
+++ b/src/core/database/storage/ProfileModelStorage.ts
@@ -16,6 +16,10 @@
 
 import { VersionedObjectStorage } from '@/core/database/backends/VersionedObjectStorage';
 import { ProfileModel } from '@/core/database/entities/ProfileModel';
+import { defaultTestnetNetworkConfig } from '@/config';
+import * as _ from 'lodash';
+import { SimpleObjectStorage } from '@/core/database/backends/SimpleObjectStorage';
+import { VersionedModel } from '@/core/database/entities/VersionedModel';
 
 export class ProfileModelStorage extends VersionedObjectStorage<Record<string, ProfileModel>> {
     /**
@@ -23,58 +27,80 @@ export class ProfileModelStorage extends VersionedObjectStorage<Record<string, P
      */
     public static INSTANCE = new ProfileModelStorage();
 
-    private constructor() {
-        super('profiles', [
-            {
-                description: 'Update profiles to 0.9.5.1 network',
-                migrate: (from: any) => {
-                    // update all pre-0.9.5.1 profiles
-                    const profiles = Object.keys(from);
+    public constructor(delegate = new SimpleObjectStorage<VersionedModel<Record<string, ProfileModel>>>('profiles')) {
+        super({
+            delegate: delegate,
+            migrations: [
+                {
+                    description: 'Update profiles to 0.9.5.1 network',
+                    migrate: (from: any) => {
+                        // update all pre-0.9.5.1 profiles
+                        const profiles = Object.keys(from);
 
-                    const modified: any = from;
-                    profiles.map((name: string) => {
-                        modified[name] = {
-                            ...modified[name],
-                            generationHash: '4009619EB7A9F824C5D0EE0E164E0F99CCD7906A475D7768FD60B452204BD0A2',
-                        };
-                    });
+                        const modified: any = from;
+                        profiles.map((name: string) => {
+                            modified[name] = {
+                                ...modified[name],
+                                generationHash: '4009619EB7A9F824C5D0EE0E164E0F99CCD7906A475D7768FD60B452204BD0A2',
+                            };
+                        });
 
-                    return modified;
+                        return modified;
+                    },
                 },
-            },
-            {
-                description: 'Update profiles for 0.9.6.3 network (generation hash)',
-                migrate: (from: any) => {
-                    // update all pre-0.9.6.x profiles
-                    const profiles = Object.keys(from);
+                {
+                    description: 'Update profiles for 0.9.6.3 network (generation hash)',
+                    migrate: (from: any) => {
+                        // update all pre-0.9.6.x profiles
+                        const profiles = Object.keys(from);
 
-                    const modified: any = from;
-                    profiles.map((name: string) => {
-                        modified[name] = {
-                            ...modified[name],
-                            generationHash: '1DFB2FAA9E7F054168B0C5FCB84F4DEB62CC2B4D317D861F3168D161F54EA78B',
-                        };
-                    });
+                        const modified: any = from;
+                        profiles.map((name: string) => {
+                            modified[name] = {
+                                ...modified[name],
+                                generationHash: '1DFB2FAA9E7F054168B0C5FCB84F4DEB62CC2B4D317D861F3168D161F54EA78B',
+                            };
+                        });
 
-                    return modified;
+                        return modified;
+                    },
                 },
-            },
-            {
-                description: 'Reset profiles for 0.9.6.3 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Update profiles for 0.10.x network (non backwards compatible due to HD and private key profile separation)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Update profiles for 0.10.0.5 pre main network release (non backwards compatible on protocol v0.10.0.4)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-        ]);
+                {
+                    description: 'Reset profiles for 0.9.6.3 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+                {
+                    description:
+                        'Update profiles for 0.10.x network (non backwards compatible due to HD and private key profile separation)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Update profiles for 0.10.0.5 pre main network release (non backwards compatible on protocol v0.10.0.4)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Update profiles for new testnet 1.0.0.0 network (generation hash)',
+                    migrate: (from: any) => {
+                        const profiles = Object.keys(from);
+                        const modified: any = from;
+                        profiles.map((name: string) => {
+                            // Keeping the same accounts but linking to the new testnet. Existing accounts would be back to 0.
+                            if (modified[name].networkType === defaultTestnetNetworkConfig.defaultNetworkType) {
+                                modified[name] = {
+                                    ...modified[name],
+                                    generationHash: defaultTestnetNetworkConfig.networkConfigurationDefaults.generationHash,
+                                    selectedNodeUrlToConnect: _.sample(defaultTestnetNetworkConfig.nodes).url, // Random url.
+                                };
+                            }
+                        });
+                        return modified;
+                    },
+                },
+            ],
+        });
     }
 }

--- a/src/core/database/storage/SettingsModelStorage.ts
+++ b/src/core/database/storage/SettingsModelStorage.ts
@@ -26,58 +26,61 @@ export class SettingsModelStorage extends VersionedObjectStorage<Record<string, 
     public static INSTANCE = new SettingsModelStorage();
 
     private constructor() {
-        super('settings', [
-            {
-                description: 'Update settings to 0.9.5.1 network',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Update settings for 0.9.6.3 network (address changes)',
-                migrate: (from: any) => {
-                    // update all pre-0.9.6.x settings
-                    const profiles = Object.keys(from);
-
-                    const modified: any = from;
-                    profiles.map((name: string) => {
-                        modified[name] = {
-                            ...modified[name],
-                            explorerUrl: networkConfig[NetworkType.TEST_NET].explorerUrl,
-                        };
-                    });
-
-                    return modified;
+        super({
+            storageKey: 'settings',
+            migrations: [
+                {
+                    description: 'Update settings to 0.9.5.1 network',
+                    migrate: () => undefined,
                 },
-            },
-            {
-                description: 'Update settings for 0.10.x network (address changes)',
-                migrate: (from: any) => {
-                    // update all pre-0.10.x settings
-                    const settings = Object.keys(from);
+                {
+                    description: 'Update settings for 0.9.6.3 network (address changes)',
+                    migrate: (from: any) => {
+                        // update all pre-0.9.6.x settings
+                        const profiles = Object.keys(from);
 
-                    const modified: any = from;
-                    settings.map((name: string) => {
-                        modified[name] = {
-                            ...modified[name],
-                            explorerUrl: networkConfig[NetworkType.TEST_NET].explorerUrl,
-                            faucetUrl: networkConfig[NetworkType.TEST_NET].faucetUrl,
-                        };
-                    });
+                        const modified: any = from;
+                        profiles.map((name: string) => {
+                            modified[name] = {
+                                ...modified[name],
+                                explorerUrl: networkConfig[NetworkType.TEST_NET].explorerUrl,
+                            };
+                        });
 
-                    return modified;
+                        return modified;
+                    },
                 },
-            },
-            {
-                description: 'Update profiles for 0.10.0.5 pre main network release (non backwards compatible on protocol v0.10.0.4)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
-                migrate: () => undefined,
-            },
-            {
-                description: 'Reset for Symbol mainet launch.',
-                migrate: () => undefined,
-            },
-        ]);
+                {
+                    description: 'Update settings for 0.10.x network (address changes)',
+                    migrate: (from: any) => {
+                        // update all pre-0.10.x settings
+                        const settings = Object.keys(from);
+
+                        const modified: any = from;
+                        settings.map((name: string) => {
+                            modified[name] = {
+                                ...modified[name],
+                                explorerUrl: networkConfig[NetworkType.TEST_NET].explorerUrl,
+                                faucetUrl: networkConfig[NetworkType.TEST_NET].faucetUrl,
+                            };
+                        });
+
+                        return modified;
+                    },
+                },
+                {
+                    description: 'Update profiles for 0.10.0.5 pre main network release (non backwards compatible on protocol v0.10.0.4)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Reset accounts for 0.10.0.6 network (non backwards compatible)',
+                    migrate: () => undefined,
+                },
+                {
+                    description: 'Reset for Symbol mainet launch.',
+                    migrate: () => undefined,
+                },
+            ],
+        });
     }
 }


### PR DESCRIPTION
Upgraded Storage objects so they can be unit tested by mocking the low-level memory storage.
Added unit testing around Profile storage migration.

Warnings:
- Do further tests on the migration in test accounts. This touches existing profile local storage, mainnet profiles should be unaltered
- Mainnet default config doesn't seem correct. For example https://github.com/nemgrouplimited/symbol-desktop-wallet/blob/main/src/config/NetworkConfig.ts#L104 maxMosaicAtomicUnits, minNamespaceDuration, maxNamespaceDuration. Revisit the mainnet default config
- Do we need to migrate other local storage objects?
- Why this hardcoded list outside the default config https://github.com/nemgrouplimited/symbol-desktop-wallet/blob/main/src/store/Network.ts#L69? @yilmazbahadir 