### PR TITLE
Docker release image on tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,19 +33,19 @@ jobs:
 
     - stage: alpha
       name: publish alpha docker
-      script: /bin/sh travis/docker.sh
+      script: /bin/sh travis/docker.sh alpha
       if: branch = env(DEV_BRANCH) AND type = push
+      os: linux
+
+    - stage: release
+      name: publish release docker
+      script: /bin/sh travis/docker.sh release
+      if: tag IS present
       os: linux
 
     - script: npm run release:all
       name: build desktop artifacts
       if: branch = env(DEV_BRANCH) AND type = push
-      os: linux
-
-    - stage: release
-      name: release docker
-      script: /bin/sh travis/docker.sh
-      if: branch = env(RELEASE_BRANCH) AND type = api AND commit_message = env(RELEASE_MESSAGE)
       os: linux
 
     - name: release desktop artifacts, tag and update version

--- a/travis/docker.sh
+++ b/travis/docker.sh
@@ -27,10 +27,8 @@ CURRENT_VERSION=$(npm run version --silent)
 echo "Creating image ${DOCKER_IMAGE_NAME}:${CURRENT_VERSION}"
 docker build -t "${DOCKER_IMAGE_NAME}:${CURRENT_VERSION}" .
 
-if [ "$TRAVIS_BRANCH" = "$DEV_BRANCH" ]
+if [ "$1" = "alpha" ]
 then
-    echo "Building for ${DEV_BRANCH} branch..."
-
     TIMESTAMP="$(date +%Y%m%d%H%M)"
     echo "Docker tagging alpha version"
     docker tag "${DOCKER_IMAGE_NAME}:${CURRENT_VERSION}" "${DOCKER_IMAGE_NAME}:${CURRENT_VERSION}-alpha"
@@ -41,9 +39,8 @@ then
     docker push "${DOCKER_IMAGE_NAME}:${CURRENT_VERSION}-alpha-${TIMESTAMP}"
 fi
 
-if [ "$TRAVIS_BRANCH" = "$RELEASE_BRANCH" ]
+if [ "$1" = "release" ]
 then
-    echo "Building for ${RELEASE_BRANCH} branch..."
     echo "Docker tagging release version"
     docker tag "${DOCKER_IMAGE_NAME}:${CURRENT_VERSION}" "${DOCKER_IMAGE_NAME}:release"
 


### PR DESCRIPTION
Currently, Travis is only building the alpha images. I would like to automize the final release images, Travis will pick the tag and create the docker images in dockerhub. 

I've tested the scripts by tagging my fork. It created https://hub.docker.com/layers/fboucquez/symbol-desktop-wallet/1.0.1/images/sha256-f511738c32b2352802301282ee23546c0e5e556cb6e127726537c844056a943f?context=explore