### PR TITLE
Post-launch Opt-in transaction view. Cosign and config file changes

### DIFF
--- a/src/components/TransactionDetails/TransactionOptinPayoutDetails.vue
+++ b/src/components/TransactionDetails/TransactionOptinPayoutDetails.vue
@@ -20,7 +20,7 @@
                             <td class="amount-text">
                                 <MosaicAmountDisplay
                                     v-if="amount !== null"
-                                    :id="transferredMosaicId"
+                                    :id="mosaicId"
                                     :absolute-amount="amount"
                                     :show-ticker="true"
                                     color="green"

--- a/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignatureTs.ts
+++ b/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignatureTs.ts
@@ -164,7 +164,7 @@ export class ModalTransactionCosignatureTs extends Vue {
         const innerTransferTransaction = this.transaction.innerTransactions.find(
             (innerTransaction) =>
                 innerTransaction.type === TransactionType.TRANSFER &&
-                (innerTransaction as TransferTransaction).recipientAddress.equals(Address.createFromRawAddress(currentAddress)),
+                (innerTransaction as TransferTransaction).recipientAddress?.equals(Address.createFromRawAddress(currentAddress)),
         );
         if (!innerTransferTransaction) {
             return false;

--- a/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignatureTs.ts
+++ b/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignatureTs.ts
@@ -25,7 +25,7 @@ import {
     NetworkType,
     TransactionStatus,
     TransactionType,
-    TransferTransaction
+    TransferTransaction,
 } from 'symbol-sdk';
 import { mapGetters } from 'vuex';
 
@@ -159,9 +159,10 @@ export class ModalTransactionCosignatureTs extends Vue {
                 innerTransaction.type === TransactionType.TRANSFER &&
                 (innerTransaction as TransferTransaction).recipientAddress?.plain() === currentAddress,
         );
-        
-        if (!innerTransferTransaction)
+
+        if (!innerTransferTransaction) {
             return false;
+        }
 
         // Check wether the signer of the Aggregate Bonded is the NGL Finance bot.
         const networktype = this.currentProfile.networkType === NetworkType.MAIN_NET ? 'mainnet' : 'testnet';

--- a/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignatureTs.ts
+++ b/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignatureTs.ts
@@ -16,6 +16,7 @@
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import {
     Account,
+    Address,
     AccountAddressRestrictionTransaction,
     AggregateTransaction,
     AggregateTransactionCosignature,
@@ -163,7 +164,7 @@ export class ModalTransactionCosignatureTs extends Vue {
         const innerTransferTransaction = this.transaction.innerTransactions.find(
             (innerTransaction) =>
                 innerTransaction.type === TransactionType.TRANSFER &&
-                (innerTransaction as TransferTransaction).recipientAddress?.plain() === currentAddress,
+                (innerTransaction as TransferTransaction).recipientAddress.equals(Address.createFromRawAddress(currentAddress)),
         );
         if (!innerTransferTransaction) {
             return false;

--- a/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignatureTs.ts
+++ b/src/views/modals/ModalTransactionCosignature/ModalTransactionCosignatureTs.ts
@@ -148,7 +148,13 @@ export class ModalTransactionCosignatureTs extends Vue {
      * Returns whether aggregate bonded transaction is announced by NGL Finance bot
      */
     public get isOptinPayoutTransaction(): boolean {
+        // Check wether the 'transaction' prop is provided.
         if (!this.transaction) {
+            return false;
+        }
+
+        // Check wether the Aggregate Bonded doesn't need a current account cosignature.
+        if (this.hasMissSignatures && this.needsCosignature) {
             return false;
         }
 
@@ -159,7 +165,6 @@ export class ModalTransactionCosignatureTs extends Vue {
                 innerTransaction.type === TransactionType.TRANSFER &&
                 (innerTransaction as TransferTransaction).recipientAddress?.plain() === currentAddress,
         );
-
         if (!innerTransferTransaction) {
             return false;
         }

--- a/vue.config.js
+++ b/vue.config.js
@@ -25,32 +25,26 @@ module.exports = {
   chainWebpack: (config) => {
     config.plugin('define').tap((args) => {
       const env = args[0]['process.env'];
-      let keys;
-      let keysFinance;
+      const dataPlaceholder = {
+        testnet: [],
+        mainnet: []
+      };
+      let configFile;
 
       try {
-        keys = require('./keys-whitelist.json');
+        configFile = require('./keys-whitelist.json');
       } catch {
-        keys = {
-          mainnet: [],
-          testnet: []
-        }
-      }
-
-      try {
-        keysFinance = require('./keys-finance.json');
-      } catch {
-        keysFinance = {
-          mainnet: [],
-          testnet: []
-        }
+        configFile = {
+          preLaunchOptin: dataPlaceholder,
+          nglFinanceBot: dataPlaceholder
+        };
       }
       args[0]['process.env'] = {
           ...env,
           PACKAGE_VERSION: packageVersion,
           WEB: web,
-          KEYS_WHITELIST: JSON.stringify(keys),
-          KEYS_FINANCE: JSON.stringify(keysFinance)
+          KEYS_WHITELIST: JSON.stringify(configFile.preLaunchOptin),
+          KEYS_FINANCE: JSON.stringify(configFile.nglFinanceBot)
       };
       return args;
     });

--- a/vue.config.js
+++ b/vue.config.js
@@ -33,7 +33,8 @@ module.exports = {
 
       try {
         configFile = require('./keys-whitelist.json');
-      } catch {
+      } catch(e) {
+        console.error('Failed to read "keys-whitelist.json"', e);
         configFile = {
           preLaunchOptin: dataPlaceholder,
           nglFinanceBot: dataPlaceholder


### PR DESCRIPTION
- Don't show Opt-in tx view, if this tx needs current account signature
- Don't show Opt-in tx view. if this tx doesn't have inner Transfer with the current account address as a recipient
- Changed config structure:

`keys-whitelist.json`
```
{
    "preLaunchOptin": {
        "testnet": [],
        "mainnet": []
    },
    "nglFinanceBot": {
        "testnet": [],
        "mainnet": []
    }
}
```