### PR TITLE
fix un-signed/partial transactions disappear after signing another partial #1487

### DIFF
--- a/src/components/MaxFeeSelector/MaxFeeSelector.vue
+++ b/src/components/MaxFeeSelector/MaxFeeSelector.vue
@@ -23,9 +23,6 @@
             <Icon type="ios-warning-outline" />
             {{ $t('low_fee_warning_message') }}
         </span>
-        <span v-else-if="transactionFees.minFeeMultiplier && !displayOnly" style="color: #ff9600;">
-            {{ $t('minimal_fee_transaction') + transactionFees.minFeeMultiplier.toString() }}
-        </span>
     </div>
 </template>
 

--- a/src/store/Transaction.ts
+++ b/src/store/Transaction.ts
@@ -522,7 +522,11 @@ export default {
             // update the partial transaction cosignatures
             transactions[index] = transactions[index].addCosignatures([cosignature]);
 
-            commit('partialTransactions', transactions);
+            commit('partialTransactions', {
+                transactions: transactions,
+                refresh: true,
+                pageInfo: getters['currentConfirmedPage'],
+            });
             commit('setAllTransactions');
             commit('filterTransactions', {
                 filterOption: null,


### PR DESCRIPTION
- fixes #1487, #1340.
- remove redundant note mentioning minimal fee multiplier fixes #1443
