### PR TITLE
Fix balance aligment

### DIFF
--- a/src/components/TableRow/TableRow.less
+++ b/src/components/TableRow/TableRow.less
@@ -36,10 +36,6 @@
     padding: 0.2rem 0.1rem 0 0.1rem;
 }
 
-.balance-cell {
-    padding-top: 0.16rem;
-}
-
 .amount-display {
     text-align: right;
 }


### PR DESCRIPTION
Fix CSS issue for balance display on Mosaic tab's Owned mosaics table.

Resolved: #1498 