### PR TITLE
Fix namespace duration issue.

### DIFF
--- a/src/services/NamespaceService.ts
+++ b/src/services/NamespaceService.ts
@@ -94,8 +94,8 @@ export class NamespaceService {
         const expiredIn = endHeight - namespaceGracePeriodBlocks - currentHeight;
         const deletedIn = endHeight - currentHeight;
         const expiration = expired
-            ? TimeHelpers.durationToRelativeTime(expiredIn, blockGenerationTargetTime)
-            : TimeHelpers.durationToRelativeTime(deletedIn, blockGenerationTargetTime);
+            ? TimeHelpers.durationToRelativeTime(deletedIn, blockGenerationTargetTime)
+            : TimeHelpers.durationToRelativeTime(expiredIn, blockGenerationTargetTime);
         return { expired, expiration };
     }
 


### PR DESCRIPTION
### Fix
- `deletedIn` will have 1-day extra compare to `expiredIn`, so when a namespace is expired, it should display `deletedIn` else it should show `expiredIn`

Resolved: #1525