### PR TITLE
Fix offline tx.

### DIFF
--- a/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
+++ b/src/views/forms/FormTransferTransaction/FormTransferTransactionTs.ts
@@ -344,6 +344,18 @@ export class FormTransferTransactionTs extends FormTransactionBase {
      */
     protected getTransactions(): TransferTransaction[] {
         const mosaicsInfo = this.$store.getters['mosaic/mosaics'] as MosaicModel[];
+
+        // Push network currency info for offline transaction format amount to absolute
+        if (mosaicsInfo.length === 0) {
+            mosaicsInfo.push({
+                mosaicIdHex: this.networkCurrency.mosaicIdHex,
+                divisibility: this.networkCurrency.divisibility,
+                name: this.networkCurrency.namespaceIdFullname,
+                isCurrencyMosaic: true,
+                balance: 0,
+            } as MosaicModel);
+        }
+
         const mosaics = this.formItems.attachedMosaics
             .filter((attachment) => attachment.uid) // filter out null values
             .map(


### PR DESCRIPTION
### Fix
- Because of offline mode, getter store `mosaic/mosaics` return empty, can't get network currency's divisibility.

Note: 
1. To test this, **turn off** your internet connection, **clear** local storage on your browser.
2. created offline tx and download the QR code.
3. **Turn on** internet and log in to your wallet. 
4. selected `Import QR code` and use that QR code you downloaded.



Resolved: #1473 