### PR TITLE
Fix node storage indexed by profileName

### DIFF
--- a/__tests__/database/storage/NodeModelStorage.spec.ts
+++ b/__tests__/database/storage/NodeModelStorage.spec.ts
@@ -20,67 +20,47 @@ import { SimpleObjectStorage } from '@/core/database/backends/SimpleObjectStorag
 import { VersionedModel } from '@/core/database/entities/VersionedModel';
 import { NodeModel } from '@/core/database/entities/NodeModel';
 import { NodeModelStorage } from '@/core/database/storage/NodeModelStorage';
+import { ProfileModel } from '@/core/database/entities/ProfileModel';
+
+const fakeProfile: ProfileModel = {
+    profileName: 'fakeName',
+    generationHash: 'fakeGenHash',
+    hint: 'fakeHint',
+    networkType: NetworkType.TEST_NET,
+    password: 'fakePassword',
+    seed: 'fakeSeed',
+    accounts: [],
+    termsAndConditionsApproved: true,
+    selectedNodeUrlToConnect: 'fakeNode',
+};
+
+const fakeNode: NodeModel = {
+    url: 'fakeNodeUrl',
+    friendlyName: 'fakeNode',
+    isDefault: false,
+    networkType: NetworkType.TEST_NET,
+};
 
 describe('storage/ProfileModelStorage.spec ==>', () => {
     describe('constructor() should', () => {
-        test('Should upgrade testnet only on v8', () => {
+        test('Should save nodes by profile name', () => {
             const nodes = {
-                version: 8,
-                data: [
-                    {
-                        url: 'http://someMainnet.symbolblockchain.io:3000',
-                        friendlyName: 'ngl-someMainnet-403',
-                        isDefault: true,
-                        networkType: NetworkType.MAIN_NET,
-                        publicKey: 'EF1209DC3C42B6450BEF658D404252DF2E26784CECD35FAEB19D929AE030A198',
-                        nodePublicKey: 'B87704DB1310FC59C91A1858DBDCFC67289363C18A67E10AFC2DCD26458B5D47',
-                    },
-                    {
-                        url: 'http://someOldtestet.symbolblockchain.io:3000',
-                        friendlyName: 'ngl-someOldtestet-001',
-                        isDefault: true,
-                        networkType: NetworkType.TEST_NET,
-                    },
-                    {
-                        url: 'http://someOldtestet2.symbolblockchain.io:3000',
-                        friendlyName: 'ngl-someOldtestet2-002',
-                        isDefault: true,
-                        networkType: NetworkType.TEST_NET,
-                    },
-                    {
-                        url: 'http://somePrivate.symbolblockchain.io:3000',
-                        friendlyName: 'ngl-somePrivate-002',
-                        isDefault: true,
-                        networkType: NetworkType.PRIVATE_TEST,
-                    },
-                ],
+                version: 10,
+                data: {
+                    [fakeProfile.profileName]: [fakeNode],
+                },
             };
-            const delegate = new SimpleObjectStorage<VersionedModel<NodeModel[]>>(
+            const delegate = new SimpleObjectStorage<VersionedModel<Record<string, NodeModel[]>>>(
                 'node',
                 new ObjectStorageBackend({
                     node: JSON.stringify(nodes),
                 }),
             );
             const storage = new NodeModelStorage(delegate);
-            const migratedData = storage.get();
-            const expected = [
-                {
-                    url: 'http://someMainnet.symbolblockchain.io:3000',
-                    friendlyName: 'ngl-someMainnet-403',
-                    isDefault: true,
-                    networkType: NetworkType.MAIN_NET,
-                    publicKey: 'EF1209DC3C42B6450BEF658D404252DF2E26784CECD35FAEB19D929AE030A198',
-                    nodePublicKey: 'B87704DB1310FC59C91A1858DBDCFC67289363C18A67E10AFC2DCD26458B5D47',
-                },
-                {
-                    url: 'http://somePrivate.symbolblockchain.io:3000',
-                    friendlyName: 'ngl-somePrivate-002',
-                    isDefault: true,
-                    networkType: NetworkType.PRIVATE_TEST,
-                },
-            ];
-            expect(migratedData).toEqual(expected);
-            expect(delegate.get()).toEqual({ version: 9, data: migratedData });
+            const storedData = storage.get();
+            expect(storedData).toEqual({
+                [fakeProfile.profileName]: [fakeNode],
+            });
         });
     });
 });

--- a/__tests__/e2e/NodeServiceIntegrationTest.spec.ts
+++ b/__tests__/e2e/NodeServiceIntegrationTest.spec.ts
@@ -18,6 +18,7 @@ import { NodeService } from '@/services/NodeService';
 import { toArray } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { instance, mock, when } from 'ts-mockito';
+import { ProfileModel } from '@/core/database/entities/ProfileModel';
 
 const nodeService = new NodeService();
 const realUrl = 'http://api-01.us-west-1.symboldev.network:3000';
@@ -45,9 +46,21 @@ when(mockRepoFactory.getEpochAdjustment()).thenReturn(of(1573430400));
 when(mockRepoFactory.getNetworkType()).thenReturn(of(NetworkType.MIJIN_TEST));
 const repositoryFactory = instance(mockRepoFactory);
 
+const fakeProfile: ProfileModel = {
+    profileName: 'fakeName',
+    generationHash: 'fakeGenHash',
+    hint: 'fakeHint',
+    networkType: NetworkType.TEST_NET,
+    password: 'fakePassword',
+    seed: 'fakeSeed',
+    accounts: [],
+    termsAndConditionsApproved: true,
+    selectedNodeUrlToConnect: 'fakeNode',
+};
+
 describe('services/NodeService', () => {
     test('getNodes', async () => {
-        const peers = await nodeService.getNodes(repositoryFactory, realUrl, NetworkType.TEST_NET).pipe(toArray()).toPromise();
+        const peers = await nodeService.getNodes(fakeProfile, repositoryFactory, realUrl).pipe(toArray()).toPromise();
         console.log(JSON.stringify(peers, null, 2));
     });
 });

--- a/src/core/database/storage/NodeModelStorage.ts
+++ b/src/core/database/storage/NodeModelStorage.ts
@@ -20,13 +20,13 @@ import { SimpleObjectStorage } from '@/core/database/backends/SimpleObjectStorag
 import { VersionedModel } from '@/core/database/entities/VersionedModel';
 import { NetworkType } from 'symbol-sdk';
 
-export class NodeModelStorage extends VersionedObjectStorage<NodeModel[]> {
+export class NodeModelStorage extends VersionedObjectStorage<Record<string, NodeModel[]>> {
     /**
      * Singleton instance as we want to run the migration just once
      */
     public static INSTANCE = new NodeModelStorage();
 
-    public constructor(delegate = new SimpleObjectStorage<VersionedModel<NodeModel[]>>('node')) {
+    public constructor(delegate = new SimpleObjectStorage<VersionedModel<Record<string, NodeModel[]>>>('node')) {
         super({
             delegate: delegate,
             migrations: [
@@ -63,6 +63,10 @@ export class NodeModelStorage extends VersionedObjectStorage<NodeModel[]> {
                     migrate: (data: NodeModel[]) => {
                         return data.filter((n) => n.networkType !== NetworkType.TEST_NET);
                     },
+                },
+                {
+                    description: 'Reset nodes for node storage fix (non backwards compatible)',
+                    migrate: () => undefined,
                 },
             ],
         });

--- a/src/services/NodeService.ts
+++ b/src/services/NodeService.ts
@@ -22,6 +22,7 @@ import { NodeModel } from '@/core/database/entities/NodeModel';
 import * as _ from 'lodash';
 import { networkConfig } from '@/config';
 import { NodeModelStorage } from '@/core/database/storage/NodeModelStorage';
+import { ProfileModel } from '@/core/database/entities/ProfileModel';
 
 /**
  * The service in charge of loading and caching anything related to Node and Peers from Rest.
@@ -33,21 +34,30 @@ export class NodeService {
      */
     private readonly storage = NodeModelStorage.INSTANCE;
 
-    public getKnowNodesOnly(networkType: NetworkType): NodeModel[] {
-        return _.uniqBy(this.loadNodes().concat(this.loadStaticNodes(networkType)), 'url').filter((n) => n.networkType === networkType);
+    public getKnowNodesOnly(profile: ProfileModel): NodeModel[] {
+        return _.uniqBy(this.loadNodes(profile).concat(this.loadStaticNodes(profile.networkType)), 'url').filter(
+            (n) => n.networkType === profile.networkType,
+        );
     }
 
-    public getNodes(repositoryFactory: RepositoryFactory, repositoryFactoryUrl: string, networkType: NetworkType): Observable<NodeModel[]> {
-        const storedNodes = this.getKnowNodesOnly(networkType);
+    public getNodes(profile: ProfileModel, repositoryFactory: RepositoryFactory, repositoryFactoryUrl: string): Observable<NodeModel[]> {
+        const storedNodes = this.getKnowNodesOnly(profile);
         const nodeRepository = repositoryFactory.createNodeRepository();
 
         return nodeRepository.getNodeInfo().pipe(
             map((dto: NodeInfo) =>
-                this.createNodeModel(repositoryFactoryUrl, networkType, dto.friendlyName, undefined, dto.publicKey, dto.nodePublicKey),
+                this.createNodeModel(
+                    repositoryFactoryUrl,
+                    profile.networkType,
+                    dto.friendlyName,
+                    undefined,
+                    dto.publicKey,
+                    dto.nodePublicKey,
+                ),
             ),
-            ObservableHelpers.defaultLast(this.createNodeModel(repositoryFactoryUrl, networkType)),
+            ObservableHelpers.defaultLast(this.createNodeModel(repositoryFactoryUrl, profile.networkType)),
             map((currentNode) => _.uniqBy([currentNode, ...storedNodes], 'url')),
-            tap((p) => this.saveNodes(p)),
+            tap((p) => this.saveNodes(profile, p)),
         );
     }
 
@@ -75,12 +85,15 @@ export class NodeService {
         );
     }
 
-    private loadNodes(): NodeModel[] {
-        return this.storage.get() || [];
+    private loadNodes(profile: ProfileModel): NodeModel[] {
+        const allProfileNodes = this.storage.get() || {};
+        return allProfileNodes[profile.profileName] || [];
     }
 
-    public saveNodes(nodes: NodeModel[]) {
-        this.storage.set(nodes);
+    public saveNodes(profile: ProfileModel, nodes: NodeModel[]) {
+        const allProfileNodes = this.storage.get() || {};
+        allProfileNodes[profile.profileName] = nodes;
+        this.storage.set(allProfileNodes);
     }
 
     public reset() {


### PR DESCRIPTION
**Not backward compatible, this removes previous node storage**

Now node storage is indexed by profileName and custom nodes are not being removed when switching profiles