### PR TITLE
fix: encrypt console error

### DIFF
--- a/src/views/forms/FormProfileUnlock/FormProfileUnlockTs.ts
+++ b/src/views/forms/FormProfileUnlock/FormProfileUnlockTs.ts
@@ -100,7 +100,7 @@ export class FormProfileUnlockTs extends Vue {
 
     public mounted(): void {
         if (this.focus) {
-            this.$nextTick().then(() => (this.$refs['passwordInput'] as any).focus());
+            this.$nextTick().then(() => (this.$refs['passwordInput'] as any).$el.focus());
         }
     }
 


### PR DESCRIPTION
### Fix
- console error message, when you check on the box for encrypting a message in tranasction.

Resolved: #1566 